### PR TITLE
[BLOCKING] Clone optimade-python-tools and run docker-compose

### DIFF
--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Set up and run regular server
         run: |
-          git clone git@github.com:Materials-Consortia/optimade-python-tools.git
+          git clone https://github.com/Materials-Consortia/optimade-python-tools
           docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade &
           .github/workflows/wait_for_it.sh localhost:3213 -t 120
           sleep 15
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set up and run index server
         run: |
-          git clone git@github.com:Materials-Consortia/optimade-python-tools.git
+          git clone https://github.com/Materials-Consortia/optimade-python-tools
           docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade-index &
           .github/workflows/wait_for_it.sh localhost:3214 -t 120
           sleep 15
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set up and run regular server (which includes all versioned base URLs)
         run: |
-          git clone git@github.com:Materials-Consortia/optimade-python-tools.git
+          git clone https://github.com/Materials-Consortia/optimade-python-tools
           docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade &
           .github/workflows/wait_for_it.sh localhost:3213 -t 120
           sleep 15

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Set up and run regular server
         run: |
-          docker-compose up optimade &
+          git clone git@github.com:Materials-Consortia/optimade-python-tools.git
+          docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade &
           .github/workflows/wait_for_it.sh localhost:3213 -t 120
           sleep 15
 
@@ -36,7 +37,8 @@ jobs:
 
       - name: Set up and run index server
         run: |
-          docker-compose up optimade-index &
+          git clone git@github.com:Materials-Consortia/optimade-python-tools.git
+          docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade-index &
           .github/workflows/wait_for_it.sh localhost:3214 -t 120
           sleep 15
 
@@ -56,7 +58,8 @@ jobs:
 
       - name: Set up and run regular server (which includes all versioned base URLs)
         run: |
-          docker-compose up optimade &
+          git clone git@github.com:Materials-Consortia/optimade-python-tools.git
+          docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade &
           .github/workflows/wait_for_it.sh localhost:3213 -t 120
           sleep 15
 


### PR DESCRIPTION
Fixes #2 

The initial work-around here is to `git clone` the `optimade-python-repository` into the temporary GH Actions server and - without installing anything - run the `docker-compose.yml` file found in the repository root of `optimade-python-repository`.