### PR TITLE
Add parameter to choose optimade-python-tools version, branch, tag or commit

### DIFF
--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -77,6 +77,19 @@ jobs:
           path: ""
           all versioned paths: yes
 
+  bats:
+    runs-on: ubuntu-latest
+    name: Run BATS test suite for entrypoint.sh
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Build BATS environment
+        run: docker build -t optimade_bats ./tests
+
+      - name: Run BATS tests
+        run: ./run_tests.sh
+
   validator_version:
     runs-on: ubuntu-latest
     name: Use validator from git commit sha

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -76,3 +76,24 @@ jobs:
           port: 3213
           path: ""
           all versioned paths: yes
+
+  validator_version:
+    runs-on: ubuntu-latest
+    name: Use validator from git commit sha
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up and run regular server
+        run: |
+          git clone https://github.com/Materials-Consortia/optimade-python-tools
+          docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade &
+          .github/workflows/wait_for_it.sh localhost:3213 -t 120
+          sleep 15
+
+      - name: Run action
+        uses: ./
+        with:
+          port: 3213
+          path: /v0
+          validator version: 141296ff395f129fad689ed9e36eba13b4e854bb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3.7
 
-RUN pip install -U pip setuptools wheel \
-    && git clone https://github.com/Materials-Consortia/optimade-python-tools \
-    && pip install -U -e ./optimade-python-tools
-
 RUN echo $(ip route | awk '{print $3}') > /docker_host_ip
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -70,3 +70,12 @@ If this is `'false'`, the input `'path'` MUST include the version part (e.g., `'
 
 **Optional** Whether or not this is an index meta-database.  
 **Default**: `false`
+
+### `validator version`
+
+**Required** Full version of an OPTiMaDe Python tools release to PyPI, e.g., `'0.6.0'` or `'0.3.4'`, which hosts the `optimade_validator`.
+It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., `'master'`, `'v0.6.0'` or `'5a5e903'`.
+See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#git) for more information of what is allowed here.
+Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.
+Note, for the latest development version, choose `'master'`.
+**Default**: `latest`

--- a/README.md
+++ b/README.md
@@ -79,3 +79,42 @@ See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/
 Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.
 Note, for the latest development version, choose `'master'`.
 **Default**: `latest`
+
+## Running test suite (developers)
+
+The test suite is based on [BATS](https://github.com/bats-core/bats-core) and should be run in [docker](https://github.com/bats-core/bats-core#running-bats-in-docker).
+The reason to run in docker, is that the `entrypoint.sh` file will install the `optimade` package.
+And to not pollute your local environment, it is safer to run it in a docker container.
+
+Steps to setup your test environment:
+
+1. Git clone this repository to your local environment
+1. Install docker (this depends on your OS, see [the docker documentation](https://docs.docker.com/install/))
+1. Run in a terminal (based on a Unix system):
+
+   ```sh
+   cd /path/to/optimade-validator-action
+   docker build --tag optimade_bats ./tests
+   ```
+
+Now you can run
+
+```sh
+docker run -i -v "$(pwd):/code" --workdir /code/tests optimade_bats .
+```
+
+or
+
+```sh
+./run_tests.sh
+```
+
+This is a file that contains the previous line and runs it, for posterity.
+Furthermore, it takes one argument: the docker tag.
+So if you named the built docker image something different from `optimade_bats`, you can pass the name to `run_tests.sh` and it will work, e.g.,
+
+```sh
+./run_tests.sh my_custom_image_name
+```
+
+will run the tests with image `my_custom_image_name` instead of `optimade_bats`.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,15 @@ inputs:
     description: Whether or not this is an index meta-database
     required: false
     default: false
+  validator version:
+    description: >
+      Full version of an OPTiMaDe Python tools release to PyPI, e.g., '0.6.0' or '0.3.4', which hosts the `optimade_validator`.
+      It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., 'master', 'v0.6.0' or '5a5e903'.
+      See https://pip.pypa.io/en/latest/reference/pip_install/#git for more information of what is allowed here.
+      Finally, it may also be 'latest' (default), which is understood to be the latest official release of the `optimade` package on PyPI.
+      Note, for the latest development version, choose 'master'.
+    required: true
+    default: latest
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ fi
 DOCKER_HOST_IP=$(cat /docker_host_ip)
 echo ${DOCKER_HOST_IP} gh_actions_host >> /etc/hosts
 
-run_validator="optimade_validator"
+run_validator="optimade_validator --verbosity 2"
 
 if [ ! -z "${INPUT_PORT}" ]; then
     BASE_URL="${INPUT_PROTOCOL}://${INPUT_DOMAIN}:${INPUT_PORT}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+# Install OPTiMaDe Python tools
+if [ "${INPUT_VALIDATOR_VERSION}" = "latest" ]; then
+    echo "Installing latest version of optimade"
+    python -m pip install --no-cache -U --upgrade-strategy=eager optimade
+elif echo ${INPUT_VALIDATOR_VERSION} | grep -Eq '^[0-9]\.[0-9]\.[0-9]$'; then
+    echo "Installing version ${INPUT_VALIDATOR_VERSION} of optimade"
+    python -m pip install --no-cache optimade==$1
+elif echo ${INPUT_VALIDATOR_VERSION} | grep -Eq '^v[0-9]\.[0-9]\.[0-9]$'; then
+    OPTIMADE_VERSION=$(echo ${INPUT_VALIDATOR_VERSION} | cut -c 2-)
+    echo "Installing version ${OPTIMADE_VERSION} of optimade"
+    python -m pip install --no-cache optimade==${OPTIMADE_VERSION}
+else
+    echo "Installing branch, tag or commit ${INPUT_VALIDATOR_VERSION} of optimade (from GitHub)"
+    python -m pip install --no-cache "https://github.com/Materials-Consortia/optimade-python-tools/tarball/${INPUT_VALIDATOR_VERSION}"
+fi
+
 # Retrieve and add GitHub Actions host runner IP to known hosts
 DOCKER_HOST_IP=$(cat /docker_host_ip)
 echo ${DOCKER_HOST_IP} gh_actions_host >> /etc/hosts

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+DOCKER_BATS_IMAGE_NAME=optimade_bats
+
+if [ -n "$1" ]; then
+    DOCKER_BATS_IMAGE_NAME=$1
+fi
+
+docker run -i -v "$(pwd):/code" --workdir /code/tests $DOCKER_BATS_IMAGE_NAME .

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,10 @@
+FROM bats/bats
+
+RUN echo "**** install Python 3 ****" && \
+    apk add --no-cache python3 && \
+    if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
+    echo "**** install pip ****" && \
+    python -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --no-cache --upgrade pip setuptools wheel && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi

--- a/tests/test_validator_version.bats
+++ b/tests/test_validator_version.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "Test passing 'latest' works" {
+    export INPUT_VALIDATOR_VERSION=latest
+    run ../entrypoint.sh
+    [ "${lines[0]}" = "Installing latest version of optimade" ]
+}
+
+@test "Test passing valid version" {
+    export INPUT_VALIDATOR_VERSION=0.6.0
+    run ../entrypoint.sh
+    [ "${lines[0]}" = "Installing version $INPUT_VALIDATOR_VERSION of optimade" ]
+}
+
+@test "Test passing valid version prefixed with 'v'" {
+    export INPUT_VALIDATOR_VERSION=v0.6.0
+    OUTPUT_OPTIMADE_VERSION=0.6.0
+    run ../entrypoint.sh
+    [ "${lines[0]}" = "Installing version $OUTPUT_OPTIMADE_VERSION of optimade" ]
+}
+
+@test "Test passing branch" {
+    export INPUT_VALIDATOR_VERSION=master
+    run ../entrypoint.sh
+    [ "${lines[0]}" = "Installing branch, tag or commit $INPUT_VALIDATOR_VERSION of optimade (from GitHub)" ]
+}


### PR DESCRIPTION
Close #1 

This adds the `validator version` parameter.
It is required and defaults to `'latest'`.

It accepts anything `pip` can handle to install from `git` (see [here](https://pip.pypa.io/en/latest/reference/pip_install/#git)) in terms of branches, tags, and commits.
If a version is chosen, e.g., `'0.6.0'` it will install this version from PyPI.
Finally, if `'latest'` is chosen (the default), it will install the latest version from PyPI.