### PR TITLE
Add verbosity and as_type input parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# File used for tests
+/tests/.entrypoint-run_validator.txt

--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ with:
 | Input | Description | Usage | Default |
 | :---: |    :---     | :---: |  :---:  |
 | `all_versioned_paths` | Whether to test all possible versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>If this is `'true'`, the input `'path'` MUST exempt the version part (e.g., `'/optimade'` instead of `'/optimade/v0'`).<br>If this is `'false'`, the input `'path'` MUST include the version part (e.g., `'/optimade/v0'` instead of `'/optimade'`) | Optional | `false`
+| `as_type` | Validate the request URL with the provided type, rather than scanning the entire implementation | Optional | -
 | `domain` | Domain for the OPTiMaDe URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host`
 | `index` | Whether or not this is an index meta-database | Optional | `false`
 | `path` | Path for the OPTiMaDe (versioned) base URL - MUST start with `/`<br>_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade` or `/`, otherwise it MUST be versioned, e.g., the default value | Optional | `/v0`
 | `port` | Port for the OPTiMaDe URL | Optional | `5000`
 | `protocol` | Protocol for the OPTiMaDe URL | Optional | `http`
 | `validator_version` | Full version of an OPTiMaDe Python tools release to PyPI, e.g., `'v0.6.0'` or `'0.3.4'`, which hosts the `optimade_validator`. It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., `'master'` or `'5a5e903'`.<br>See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#git) for more information of what is allowed here.<br>Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.<br>Note, for the latest development version, choose `'master'`. | **Required** | `latest`
+| `verbosity` | The verbosity of the output.<br>`0`: minimalistic, `1`: informational, `2`+: debug | Optional | `1`
 
 ## Running test suite (developers)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ with:
 | Input | Description | Usage | Default |
 | :---: |    :---     | :---: |  :---:  |
 | `all_versioned_paths` | Whether to test all possible versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>If this is `'true'`, the input `'path'` MUST exempt the version part (e.g., `'/optimade'` instead of `'/optimade/v0'`).<br>If this is `'false'`, the input `'path'` MUST include the version part (e.g., `'/optimade/v0'` instead of `'/optimade'`) | Optional | `false`
-| `as_type` | Validate the request URL with the provided type, rather than scanning the entire implementation | Optional | -
+| `as_type` | Validate the request URL with the provided type, rather than scanning the entire implementation<br>Example values: 'structures', 'reference'. For a full list of values see `optimade-python-tools`. | Optional | -
 | `domain` | Domain for the OPTiMaDe URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host`
 | `index` | Whether or not this is an index meta-database | Optional | `false`
 | `path` | Path for the OPTiMaDe (versioned) base URL - MUST start with `/`<br>_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade` or `/`, otherwise it MUST be versioned, e.g., the default value | Optional | `/v0`

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ with:
 
 | Input | Description | Usage | Default |
 | :---: |    :---     | :---: |  :---:  |
-| `protocol` | Protocol for the OPTiMaDe URL | Optional | `http`
-| `domain` | Domain for the OPTiMaDe URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host`
-| `port` | Port for the OPTiMaDe URL | Optional | `5000`
-| `path` | Path for the OPTiMaDe (versioned) base URL - MUST start with `/`<br>_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade` or `/`, otherwise it MUST be versioned, e.g., the default value | Optional | `/v0`
 | `all_versioned_paths` | Whether to test all possible versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>If this is `'true'`, the input `'path'` MUST exempt the version part (e.g., `'/optimade'` instead of `'/optimade/v0'`).<br>If this is `'false'`, the input `'path'` MUST include the version part (e.g., `'/optimade/v0'` instead of `'/optimade'`) | Optional | `false`
+| `domain` | Domain for the OPTiMaDe URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host`
 | `index` | Whether or not this is an index meta-database | Optional | `false`
+| `path` | Path for the OPTiMaDe (versioned) base URL - MUST start with `/`<br>_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade` or `/`, otherwise it MUST be versioned, e.g., the default value | Optional | `/v0`
+| `port` | Port for the OPTiMaDe URL | Optional | `5000`
+| `protocol` | Protocol for the OPTiMaDe URL | Optional | `http`
 | `validator_version` | Full version of an OPTiMaDe Python tools release to PyPI, e.g., `'v0.6.0'` or `'0.3.4'`, which hosts the `optimade_validator`. It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., `'master'` or `'5a5e903'`.<br>See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#git) for more information of what is allowed here.<br>Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.<br>Note, for the latest development version, choose `'master'`. | **Required** | `latest`
 
 ## Running test suite (developers)

--- a/action.yml
+++ b/action.yml
@@ -6,21 +6,7 @@ branding:
   color: green
 
 inputs:
-  protocol:
-    description: Protocol for the OPTiMaDe URL
-    required: false
-    default: http
-  domain:
-    description: Domain for the OPTiMaDe URL (defaults to the GH Actions runner host)
-    required: false
-    default: gh_actions_host
-  port:
-    description: Port for the OPTiMaDe URL
-    required: false
-  path:
-    description: Path of the OPTiMaDe (versioned) base URL - MUST start with '/'
-    required: false
-    default: /v0
+
   all versioned paths:
     description: >
       Whether to test all possible versioned base URLs:
@@ -29,10 +15,31 @@ inputs:
       If this is 'false', the input 'path' MUST include the version part (e.g., '/optimade/v0' instead of '/optimade').
     required: false
     default: false
+
+  domain:
+    description: Domain for the OPTiMaDe URL (defaults to the GH Actions runner host)
+    required: false
+    default: gh_actions_host
+
   index:
     description: Whether or not this is an index meta-database
     required: false
     default: false
+
+  path:
+    description: Path of the OPTiMaDe (versioned) base URL - MUST start with '/'
+    required: false
+    default: /v0
+
+  port:
+    description: Port for the OPTiMaDe URL
+    required: false
+
+  protocol:
+    description: Protocol for the OPTiMaDe URL
+    required: false
+    default: http
+
   validator version:
     description: >
       Full version of an OPTiMaDe Python tools release to PyPI, e.g., '0.6.0' or '0.3.4', which hosts the `optimade_validator`.
@@ -42,6 +49,7 @@ inputs:
       Note, for the latest development version, choose 'master'.
     required: true
     default: latest
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: false
     default: false
 
+  as type:
+    description: Validate the request URL with the provided type, rather than scanning the entire implementation
+    required: false
+
   domain:
     description: Domain for the OPTiMaDe URL (defaults to the GH Actions runner host)
     required: false
@@ -49,6 +53,11 @@ inputs:
       Note, for the latest development version, choose 'master'.
     required: true
     default: latest
+
+  verbosity:
+    description: The verbosity of the output
+    required: false
+    default: 1
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,20 @@ fi
 DOCKER_HOST_IP=$(cat /docker_host_ip)
 echo ${DOCKER_HOST_IP} gh_actions_host >> /etc/hosts
 
-run_validator="optimade_validator --verbosity 2"
+run_validator="optimade_validator"
+
+if echo ${INPUT_VERBOSITY} | grep -Eq '[^0-9]'; then
+    # Bad value for `verbosity`
+    echo "Non-valid input for 'verbosity': ${INPUT_VERBOSITY}. Will use default (1)."
+    INPUT_VERBOSITY=1
+fi
+echo "Using verbosity level: ${INPUT_VERBOSITY}"
+run_validator="${run_validator} --verbosity ${INPUT_VERBOSITY}"
+
+if [ -n "${INPUT_AS_TYPE}" ]; then
+    echo "Validating as type: ${INPUT_AS_TYPE}"
+    run_validator="${run_validator} --as_type ${INPUT_AS_TYPE}"
+fi
 
 if [ ! -z "${INPUT_PORT}" ]; then
     BASE_URL="${INPUT_PROTOCOL}://${INPUT_DOMAIN}:${INPUT_PORT}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,19 +58,27 @@ case ${INPUT_ALL_VERSIONED_PATHS} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         for version in '0' '0.10' '0.10.1'; do
             if [ "${INPUT_PATH}" = "/" ]; then
+                # For testing
+                echo "run_validator: ${run_validator}${INPUT_PATH}v${version}${index}" >> ./tests/.entrypoint-run_validator.txt
                 sh -c "${run_validator}${INPUT_PATH}v${version}${index}"
             else
+                # For testing
+                echo "run_validator: ${run_validator}${INPUT_PATH}/v${version}${index}" >> ./tests/.entrypoint-run_validator.txt
                 sh -c "${run_validator}${INPUT_PATH}/v${version}${index}"
             fi
         done
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
         run_validator="${run_validator}${INPUT_PATH}${index}"
+        # For testing
+        echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
         sh -c "${run_validator}"
         ;;
     *)
         echo "Non-valid input for 'all versioned paths': ${INPUT_ALL_VERSIONED_PATHS}. Will use default (false)."
         run_validator="${run_validator}${INPUT_PATH}${index}"
+        # For testing
+        echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
         sh -c "${run_validator}"
         ;;
 esac

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,9 +1,24 @@
 #!/bin/sh
 
 DOCKER_BATS_IMAGE_NAME=optimade_bats
+DOCKER_BATS_TEST_PATH=.
 
 if [ -n "$1" ]; then
-    DOCKER_BATS_IMAGE_NAME=$1
+    if echo "$1" | grep -Eq '*[/\.]+.*'; then
+        # TEST PATH
+        DOCKER_BATS_TEST_PATH=$1
+        if [ -n "$2" ]; then
+            # Assume IMAGE NAME
+            DOCKER_BATS_IMAGE_NAME=$2
+        fi
+    else
+        # IMAGE NAME
+        DOCKER_BATS_IMAGE_NAME=$1
+        if [ -n "$2" ]; then
+            # Assume TEST PATH
+            DOCKER_BATS_TEST_PATH=$2
+        fi
+    fi
 fi
 
-docker run -i -v "$(pwd):/code" --workdir /code/tests $DOCKER_BATS_IMAGE_NAME .
+docker run -i -v "$(pwd):/code" --workdir /code/tests $DOCKER_BATS_IMAGE_NAME $DOCKER_BATS_TEST_PATH

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DOCKER_BATS_IMAGE_NAME=optimade_bats
-DOCKER_BATS_TEST_PATH=.
+DOCKER_BATS_TEST_PATH=./tests
 
 if [ -n "$1" ]; then
     if echo "$1" | grep -Eq '*[/\.]+.*'; then
@@ -21,4 +21,4 @@ if [ -n "$1" ]; then
     fi
 fi
 
-docker run -i -v "$(pwd):/code" --workdir /code/tests $DOCKER_BATS_IMAGE_NAME $DOCKER_BATS_TEST_PATH
+docker run -i -v "$(pwd):/code" --workdir /code $DOCKER_BATS_IMAGE_NAME $DOCKER_BATS_TEST_PATH

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,10 +1,16 @@
 FROM bats/bats
 
-RUN echo "**** install Python 3 ****" && \
+RUN echo "**** Installing Python 3 ****" && \
     apk add --no-cache python3 && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
-    echo "**** install pip ****" && \
+    echo "**** Installing pip ****" && \
     python -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --no-cache --upgrade pip setuptools wheel && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi
+
+ENV BATS_TEST_HELPERS /test_helpers
+RUN echo "**** Updating BATS with bats-support and bats-assert-1 ****" && \
+    apk add --no-cache git && \
+    git clone https://github.com/jasonkarns/bats-support ${BATS_TEST_HELPERS}/bats-support && \
+    git clone https://github.com/jasonkarns/bats-assert-1 ${BATS_TEST_HELPERS}/bats-assert

--- a/tests/test_as_type.bats
+++ b/tests/test_as_type.bats
@@ -4,22 +4,28 @@ load 'test_fixtures'
 
 @test "Default as_type" {
     # There isn't a default for as_type, so it shouldn't result in --as_type being set
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     refute_output --partial "Validating as type: "
+
+    TEST_FINAL_RUN_VALIDATOR=default
 }
 
 @test "as_type='structure'" {
     VALID_AS_TYPE_VALUE=structure
     export INPUT_AS_TYPE=${VALID_AS_TYPE_VALUE}
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Validating as type: ${VALID_AS_TYPE_VALUE}"
+
+    TEST_FINAL_RUN_VALIDATOR="optimade_validator --verbosity ${INPUT_VERBOSITY} --as_type ${VALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
 }
 
 @test "as_type='non_valid_input' (invalid value, should fail with status 1 and message)" {
     INVALID_AS_TYPE_VALUE=non_valid_input
     export INPUT_AS_TYPE=${INVALID_AS_TYPE_VALUE}
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Validating as type: ${INVALID_AS_TYPE_VALUE}"
     assert_failure 1
     assert_output --partial "${INVALID_AS_TYPE_VALUE} is not a valid type, must be one of "
+
+    TEST_FINAL_RUN_VALIDATOR="optimade_validator --verbosity ${INPUT_VERBOSITY} --as_type ${INVALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
 }

--- a/tests/test_as_type.bats
+++ b/tests/test_as_type.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load 'test_fixtures'
+
+@test "Default as_type" {
+    # There isn't a default for as_type, so it shouldn't result in --as_type being set
+    run ../entrypoint.sh
+    refute_output --partial "Validating as type: "
+}
+
+@test "as_type='structure'" {
+    VALID_AS_TYPE_VALUE=structure
+    export INPUT_AS_TYPE=${VALID_AS_TYPE_VALUE}
+    run ../entrypoint.sh
+    assert_output --partial "Validating as type: ${VALID_AS_TYPE_VALUE}"
+}
+
+@test "as_type='non_valid_input' (invalid value, should fail with status 1 and message)" {
+    INVALID_AS_TYPE_VALUE=non_valid_input
+    export INPUT_AS_TYPE=${INVALID_AS_TYPE_VALUE}
+    run ../entrypoint.sh
+    assert_output --partial "Validating as type: ${INVALID_AS_TYPE_VALUE}"
+    assert_failure 1
+    assert_output --partial "${INVALID_AS_TYPE_VALUE} is not a valid type, must be one of "
+}

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Set all input parameter defaults
+export INPUT_ALL_VERSIONED_PATHS=false
+export INPUT_DOMAIN=gh_actions_host
+export INPUT_INDEX=false
+export INPUT_PATH=/v0
+export INPUT_PROTOCOL=http
+export INPUT_VALIDATOR_VERSION=latest
+export INPUT_VERBOSITY=1
+
+# Load BATS extensions (installed in ./tests/Dockerfile)
+load "${BATS_TEST_HELPERS}/bats-support/load.bash"
+load "${BATS_TEST_HELPERS}/bats-assert/load.bash"

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -1,14 +1,31 @@
 #!/usr/bin/env bash
 
-# Set all input parameter defaults
-export INPUT_ALL_VERSIONED_PATHS=false
-export INPUT_DOMAIN=gh_actions_host
-export INPUT_INDEX=false
-export INPUT_PATH=/v0
-export INPUT_PROTOCOL=http
-export INPUT_VALIDATOR_VERSION=latest
-export INPUT_VERBOSITY=1
+# Absolute path to entrypoint.sh
+export ENTRYPOINT_SH=/code/entrypoint.sh
 
 # Load BATS extensions (installed in ./tests/Dockerfile)
 load "${BATS_TEST_HELPERS}/bats-support/load.bash"
 load "${BATS_TEST_HELPERS}/bats-assert/load.bash"
+
+function setup() {
+    # Set all input parameter defaults
+    export INPUT_ALL_VERSIONED_PATHS=false
+    export INPUT_DOMAIN=gh_actions_host
+    export INPUT_INDEX=false
+    export INPUT_PATH=/v0
+    export INPUT_PROTOCOL=http
+    export INPUT_VALIDATOR_VERSION=latest
+    export INPUT_VERBOSITY=1
+
+    rm -f /code/tests/.entrypoint-run_validator.txt
+}
+
+function teardown() {
+    if [ "${TEST_FINAL_RUN_VALIDATOR}" = "default" ] || [ -z "${TEST_FINAL_RUN_VALIDATOR}" ]; then
+        TEST_FINAL_RUN_VALIDATOR="optimade_validator --verbosity 1 http://gh_actions_host/v0"
+    fi
+    run cat /code/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+
+    rm -f /code/tests/.entrypoint-run_validator.txt
+}

--- a/tests/test_validator_version.bats
+++ b/tests/test_validator_version.bats
@@ -1,26 +1,28 @@
 #!/usr/bin/env bats
 
-@test "Test passing 'latest' works" {
+load 'test_fixtures'
+
+@test "validator_version='latest'" {
     export INPUT_VALIDATOR_VERSION=latest
     run ../entrypoint.sh
-    [ "${lines[0]}" = "Installing latest version of optimade" ]
+    assert_output --partial "Installing latest version of optimade"
 }
 
-@test "Test passing valid version" {
+@test "validator_version='0.6.0'" {
     export INPUT_VALIDATOR_VERSION=0.6.0
     run ../entrypoint.sh
-    [ "${lines[0]}" = "Installing version $INPUT_VALIDATOR_VERSION of optimade" ]
+    assert_output --partial "Installing version $INPUT_VALIDATOR_VERSION of optimade"
 }
 
-@test "Test passing valid version prefixed with 'v'" {
+@test "validator_version='v0.6.0'" {
     export INPUT_VALIDATOR_VERSION=v0.6.0
     OUTPUT_OPTIMADE_VERSION=0.6.0
     run ../entrypoint.sh
-    [ "${lines[0]}" = "Installing version $OUTPUT_OPTIMADE_VERSION of optimade" ]
+    assert_output --partial "Installing version $OUTPUT_OPTIMADE_VERSION of optimade"
 }
 
-@test "Test passing branch" {
+@test "validator_version='master'" {
     export INPUT_VALIDATOR_VERSION=master
     run ../entrypoint.sh
-    [ "${lines[0]}" = "Installing branch, tag or commit $INPUT_VALIDATOR_VERSION of optimade (from GitHub)" ]
+    assert_output --partial "Installing branch, tag or commit $INPUT_VALIDATOR_VERSION of optimade (from GitHub)"
 }

--- a/tests/test_validator_version.bats
+++ b/tests/test_validator_version.bats
@@ -4,25 +4,25 @@ load 'test_fixtures'
 
 @test "validator_version='latest'" {
     export INPUT_VALIDATOR_VERSION=latest
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Installing latest version of optimade"
 }
 
 @test "validator_version='0.6.0'" {
     export INPUT_VALIDATOR_VERSION=0.6.0
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Installing version $INPUT_VALIDATOR_VERSION of optimade"
 }
 
 @test "validator_version='v0.6.0'" {
     export INPUT_VALIDATOR_VERSION=v0.6.0
     OUTPUT_OPTIMADE_VERSION=0.6.0
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Installing version $OUTPUT_OPTIMADE_VERSION of optimade"
 }
 
 @test "validator_version='master'" {
     export INPUT_VALIDATOR_VERSION=master
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Installing branch, tag or commit $INPUT_VALIDATOR_VERSION of optimade (from GitHub)"
 }

--- a/tests/test_verbosity.bats
+++ b/tests/test_verbosity.bats
@@ -4,22 +4,28 @@ load 'test_fixtures'
 
 @test "Default verbosity" {
     VERBOSITY_DEFAULT=${INPUT_VERBOSITY}  # Use value from 'test_fixtures.bash'
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
+
+    TEST_FINAL_RUN_VALIDATOR=default
 }
 
 @test "verbosity=0" {
     VALID_VERBOSITY_VALUE=0
     export INPUT_VERBOSITY=${VALID_VERBOSITY_VALUE}
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
+
+    TEST_FINAL_RUN_VALIDATOR="optimade_validator --verbosity ${VALID_VERBOSITY_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
 }
 
 @test "verbosity='test' (invalid value, should use default instead)" {
     INVALID_VERBOSITY_VALUE=test
     VERBOSITY_DEFAULT=${INPUT_VERBOSITY}  # Use value from 'test_fixtures.bash'
     export INPUT_VERBOSITY=${INVALID_VERBOSITY_VALUE}
-    run ../entrypoint.sh
+    run ${ENTRYPOINT_SH}
     assert_output --partial "Non-valid input for 'verbosity': ${INVALID_VERBOSITY_VALUE}. Will use default (1)." ]
     assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
+
+    TEST_FINAL_RUN_VALIDATOR=default
 }

--- a/tests/test_verbosity.bats
+++ b/tests/test_verbosity.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load 'test_fixtures'
+
+@test "Default verbosity" {
+    VERBOSITY_DEFAULT=${INPUT_VERBOSITY}  # Use value from 'test_fixtures.bash'
+    run ../entrypoint.sh
+    assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
+}
+
+@test "verbosity=0" {
+    VALID_VERBOSITY_VALUE=0
+    export INPUT_VERBOSITY=${VALID_VERBOSITY_VALUE}
+    run ../entrypoint.sh
+    assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
+}
+
+@test "verbosity='test' (invalid value, should use default instead)" {
+    INVALID_VERBOSITY_VALUE=test
+    VERBOSITY_DEFAULT=${INPUT_VERBOSITY}  # Use value from 'test_fixtures.bash'
+    export INPUT_VERBOSITY=${INVALID_VERBOSITY_VALUE}
+    run ../entrypoint.sh
+    assert_output --partial "Non-valid input for 'verbosity': ${INVALID_VERBOSITY_VALUE}. Will use default (1)." ]
+    assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
+}


### PR DESCRIPTION
Close #7 

This adds the possibility to pass values for the `optimade_validator` arguments `--verbosity` and `--as_type`. See [the code in `optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/blob/v0.6.0/optimade/validator/__init__.py) for more information about these arguments.

See [the updated README](https://github.com/CasperWA/optimade-validator-action/blob/close_7_add_verbosity_and_as_type/README.md#inputs) for the repurposing of the argument documentation in `optimade_validator`.

The BATS testing is also expanded upon, adding test files for both new input parameters, as well as expanding the framework with the libraries [bats-assert](https://github.com/jasonkarns/bats-assert-1) and [bats-support](https://github.com/jasonkarns/bats-support). These add assertion commands and nicer outputs.
Furthermore, `entrypoint.sh` now outputs the final `run_validator` command to a hidden txt file that is tested for all tests in a common `teardown` function. This means each test must contain information on what the final command will look like, be it the default or not.
The hidden txt file is removed before and after every test.
All default values for input parameters that would normally be set by GH Actions are set (and reset) before every test as well.