### PR TITLE
Release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This action runs `optimade_validator` from the `optimade` package found in the [
 
 All minor and patch updates to v1 will be folded into the `v1` tag, so that using the action `@v1` is recommended, since it results in using the latest v1.minor.patch.
 
+Latest versions:
+
+| Used tag | Effective version |
+| :---: | :---: |
+| `v1` | [`v1.1.0`](https://github.com/Materials-Consortia/optimade-validator-action/releases/tag/v1.1.0)
+
 ## Example usage
 
 To run `optimade_validator` for an index meta-database at `http://gh_actions_host:5001/v0` do the following:  

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,9 @@ inputs:
     default: false
 
   as type:
-    description: Validate the request URL with the provided type, rather than scanning the entire implementation
+    description: >
+      Validate the request URL with the provided type, rather than scanning the entire implementation.
+      Example values: 'structures', 'reference'. For a full list of values see `optimade-python-tools`.
     required: false
 
   domain:


### PR DESCRIPTION
This adds a small extendable table to compare the tag one should use (i.e., `v1`) with the effective version that's being run of the action.

Also, it updates the README with the documentation added for `as_type` as the last thing from #11.