### PR TITLE
Use proper variable for version installation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${INPUT_VALIDATOR_VERSION}" = "latest" ]; then
     python -m pip install --no-cache -U --upgrade-strategy=eager optimade
 elif echo ${INPUT_VALIDATOR_VERSION} | grep -Eq '^[0-9]\.[0-9]\.[0-9]$'; then
     echo "Installing version ${INPUT_VALIDATOR_VERSION} of optimade"
-    python -m pip install --no-cache -U optimade==$1
+    python -m pip install --no-cache -U optimade==${INPUT_VALIDATOR_VERSION}
 elif echo ${INPUT_VALIDATOR_VERSION} | grep -Eq '^v[0-9]\.[0-9]\.[0-9]$'; then
     OPTIMADE_VERSION=$(echo ${INPUT_VALIDATOR_VERSION} | cut -c 2-)
     echo "Installing version ${OPTIMADE_VERSION} of optimade"

--- a/tests/test_as_type.bats
+++ b/tests/test_as_type.bats
@@ -6,6 +6,7 @@ load 'test_fixtures'
     # There isn't a default for as_type, so it shouldn't result in --as-type being set
     run ${ENTRYPOINT_SH}
     refute_output --partial "Validating as type: "
+    refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
@@ -16,6 +17,7 @@ load 'test_fixtures'
     export INPUT_AS_TYPE=${VALID_AS_TYPE_VALUE}
     run ${ENTRYPOINT_SH}
     assert_output --partial "Validating as type: ${VALID_AS_TYPE_VALUE}"
+    refute_output --partial "ERROR"
 
     TEST_FINAL_RUN_VALIDATOR="optimade-validator $( for i in {1..${INPUT_VERBOSITY}}; do echo '-v '; done; )--as-type ${VALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt

--- a/tests/test_validator_version.bats
+++ b/tests/test_validator_version.bats
@@ -6,6 +6,7 @@ load 'test_fixtures'
     export INPUT_VALIDATOR_VERSION=latest
     run ${ENTRYPOINT_SH}
     assert_output --partial "Installing latest version of optimade"
+    refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
@@ -15,6 +16,7 @@ load 'test_fixtures'
     export INPUT_VALIDATOR_VERSION=0.6.0
     run ${ENTRYPOINT_SH}
     assert_output --partial "Installing version $INPUT_VALIDATOR_VERSION of optimade"
+    refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
@@ -25,6 +27,7 @@ load 'test_fixtures'
     OUTPUT_OPTIMADE_VERSION=0.6.0
     run ${ENTRYPOINT_SH}
     assert_output --partial "Installing version $OUTPUT_OPTIMADE_VERSION of optimade"
+    refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
@@ -34,6 +37,7 @@ load 'test_fixtures'
     export INPUT_VALIDATOR_VERSION=master
     run ${ENTRYPOINT_SH}
     assert_output --partial "Installing branch, tag or commit $INPUT_VALIDATOR_VERSION of optimade (from GitHub)"
+    refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"

--- a/tests/test_verbosity.bats
+++ b/tests/test_verbosity.bats
@@ -6,6 +6,7 @@ load 'test_fixtures'
     VERBOSITY_DEFAULT=${INPUT_VERBOSITY}  # Use value from 'test_fixtures.bash'
     run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
+    refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
@@ -16,6 +17,7 @@ load 'test_fixtures'
     export INPUT_VERBOSITY=${VALID_VERBOSITY_VALUE}
     run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
+    refute_output --partial "ERROR"
 
     TEST_FINAL_RUN_VALIDATOR="optimade-validator ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
@@ -39,6 +41,7 @@ load 'test_fixtures'
     export INPUT_VERBOSITY=${VALID_VERBOSITY_VALUE}
     run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
+    refute_output --partial "ERROR"
 
     TEST_FINAL_RUN_VALIDATOR="optimade-validator -v -v -v ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt


### PR DESCRIPTION
Add `refute_output` to tests that should pass without errors.

Fixes #26 