### PR TITLE
New workflow for updating version

### DIFF
--- a/.github/update_version/major_version_tag_msg.txt
+++ b/.github/update_version/major_version_tag_msg.txt
@@ -1,0 +1,3 @@
+vMAJOR
+
+This is the latest vMAJOR.MINOR.PATCH

--- a/.github/update_version/release_tag_msg.txt
+++ b/.github/update_version/release_tag_msg.txt
@@ -1,0 +1,3 @@
+TAG_NAME
+
+This tag was created using the publish GitHub Actions workflow.

--- a/.github/update_version/update_version.sh
+++ b/.github/update_version/update_version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+echo "\n### Checkout fresh branch ###"
+git checkout -b update_version
+
+echo "\n### Setting commit user ###"
+git config --local user.email "dev@optimade.org"
+git config --local user.name "OPTIMADE Developers"
+
+echo "\n### Install invoke ###"
+pip install invoke
+
+echo "\n### Update version in README ###"
+invoke setver -ver "${GITHUB_REF#refs/tags/}"
+
+echo "\n### Commit update ###"
+git add README.md
+git commit -m "Release ${GITHUB_REF#refs/tags/} - Update README"

--- a/.github/update_version/update_version.sh
+++ b/.github/update_version/update_version.sh
@@ -12,8 +12,8 @@ echo "\n### Install invoke ###"
 pip install invoke
 
 echo "\n### Update version in README ###"
-invoke setver -ver "${GITHUB_REF#refs/tags/}"
+invoke setver --ver="${GITHUB_REF#refs/tags/}"
 
 echo "\n### Commit update ###"
 git add README.md
-git commit -m "Release ${GITHUB_REF#refs/tags/} - Update README"
+git commit -m "Release ${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/update_vMAJOR.yml
+++ b/.github/workflows/update_vMAJOR.yml
@@ -1,0 +1,8 @@
+name: Update tag vMAJOR upon release of newest vMAJOR.MINOR.PATCH version
+
+on:
+  push:
+    release:
+      types: [published]
+
+jobs:

--- a/.github/workflows/update_vMAJOR.yml
+++ b/.github/workflows/update_vMAJOR.yml
@@ -6,3 +6,38 @@ on:
       types: [published]
 
 jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Materials-Consortia/optimade-validator-action' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Update version and update 'master'
+      uses: CasperWA/push-protected@v1
+      with:
+        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        changes: .github/update_version/update_version.sh
+        unprotect_reviews: true
+
+    - name: Update tags to latest commit (getting the newest version locally)
+      run: |
+        git config --local user.email "dev@optimade.org"
+        git config --local user.name "OPTIMADE Developers"
+
+        git fetch origin
+        git branch master origin/master
+        git checkout master
+
+        # Create new full version (v<MAJOR>.<MINOR>.<PATCH>) tag
+        TAG_MSG=.github/update_version/release_tag_msg.txt
+        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|g" "${TAG_MSG}"
+
+        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+
+        # Move/update v<MAJOR> tag
+        MAJOR_VERSION=$( echo ${GITHUB_REF#refs/tags/v} | cut -d "." -f 1 )
+        TAG_MSG=.github/update_version/major_version_tag_msg.txt
+        sed -i "s|MAJOR|${MAJOR_VERSION}|g" "${TAG_MSG}"
+
+        git tag -af -F "${TAG_MSG}" v${MAJOR_VERSION}
+
+        git push -f --tags

--- a/.github/workflows/update_vMAJOR.yml
+++ b/.github/workflows/update_vMAJOR.yml
@@ -1,9 +1,8 @@
 name: Update tag vMAJOR upon release of newest vMAJOR.MINOR.PATCH version
 
 on:
-  push:
-    release:
-      types: [published]
+  release:
+    types: [published]
 
 jobs:
   publish:

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - master
+    - 'push-action/**'
 
 jobs:
 

--- a/tasks.py
+++ b/tasks.py
@@ -47,4 +47,4 @@ def setver(_, ver=""):
         strip="\n",
     )
 
-    print("Bumped version to {}".format(ver))
+    print(f"Bumped version to {ver}")

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import re
+from typing import Tuple
+
+try:
+    from invoke import task
+except ImportError:
+    import sys
+
+    sys.exit("'invoke' MUST be installed to run these tasks.")
+
+
+TOP_DIR = Path(__file__).parent.resolve()
+
+
+def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None):
+    """Utility function for tasks to read, update, and write files"""
+    with open(filename, "r") as handle:
+        lines = [
+            re.sub(sub_line[0], sub_line[1], line.rstrip(strip)) for line in handle
+        ]
+
+    with open(filename, "w") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+@task(help={"ver": "OPTIMADE Validator Action version to set"})
+def setver(_, ver=""):
+    """Sets the OPTIMADE Validator Action version"""
+    match = re.fullmatch(r"v?([0-9]+\.[0-9]+\.[0-9]+)", ver)
+    if not match or (match and len(match.groups()) != 1):
+        print(
+            "Error: Please specify version as 'Major.Minor.Patch' or 'vMajor.Minor.Patch'"
+        )
+        sys.exit(1)
+    ver = match.group(1)
+
+    major_version = ver.split(".")[0]
+    tag_url = "https://github.com/Materials-Consortia/optimade-validator-action/releases/tag/"
+    update_file(
+        TOP_DIR.joinpath("README.md"),
+        (
+            fr"`v{major_version}` \| \[`v{major_version}(\.[0-9]+){{2}}.*v{major_version}(\.[0-9]+){{2}}",
+            f"`v{major_version}` | [`v{ver}`]({tag_url}v{ver}",
+        ),
+        strip="\n",
+    )
+
+    print("Bumped version to {}".format(ver))


### PR DESCRIPTION
Closes #20 

Use [`push-protected`](https://github.com/CasperWA/push-protected) to update version where needed in code base and create and update tags in the GitHub workflow afterwards.

Introduce `tasks.py` based on [`invoke`](http://www.pyinvoke.org/) to update version. This will be called in `push-protected`.