### PR TITLE
Test unversioned base URLs

### DIFF
--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./
         with:
           port: 3213
-          path: /v1
+          path: /
 
   validator_index:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
         uses: ./
         with:
           port: 3214
-          path: /v1
+          path: /
           index: yes
 
   all_versioned_paths:
@@ -109,7 +109,7 @@ jobs:
         uses: ./
         with:
           port: 3213
-          path: /v1
+          path: /
           validator version: c6551e27f64abdaa94afd401db22af9ef2afd23d
 
   validator_version_fail:
@@ -132,7 +132,7 @@ jobs:
         uses: ./
         with:
           port: 3213
-          path: /v1
+          path: /
           validator version: "0.0.0"
 
       - name: This runs ONLY if 'Run action' doesn't fail as expected

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # File used for tests
 /tests/.entrypoint-run_validator.txt
+/tests/.entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Latest versions:
 
 ## Example usage
 
-To run `optimade-validator` for an index meta-database at `http://gh_actions_host:5001/v1` do the following:  
-Within the same job, first, start a server, e.g., using the `docker-compose.yml` setup from this repository, and then add the step
+To run `optimade-validator` for an index meta-database at `http://gh_actions_host:5001/` do the following:  
+Within the same job, first, start a server, e.g., using the `docker-compose.yml` setup from the [OPTIMADE Python tools repository](https://github.com/Materials-Consortia/optimade-python-tools/blob/master/docker-compose.yml), and then add the step
 
 ```yml
 uses: Materials-Consortia/optimade-validator-action@v2
 with:
   port: 5001
-  path: /v1
+  path: /
   index: yes
 ```
 
@@ -42,16 +42,27 @@ with:
   all versioned paths: True
 ```
 
+> **Note**: This will also run `optimade-validator` for the unversioned base URL.
+
+By default, the validator follows the [OPTIMADE specification](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst).
+This means it will always check the mandatory base URLs:
+
+- Unversioned base URL (`/`)
+- Major-versioned base URL (`/vMAJOR`, e.g. `/v1`)
+
+The major version number will be determined based on the validator version used, i.e., the supported OPTIMADE API version in the [OPTIMADE Python tools repository](https://github.com/Materials-Consortia/optimade-python-tools/blob/master/optimade/__init__.py#L2).
+This can be chosen using the input `validator_version`.
+
 ## Inputs
 
 | Input | Description | Usage | Default | Action version |
 | :---: |    :---     | :---: |  :---:  |      :---:     |
-| `all_versioned_paths` | Whether to test all possible versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>If this is `'true'`, the input `'path'` MUST exempt the version part (e.g., `'/optimade'` instead of `'/optimade/v1'`).<br>If this is `'false'`, the input `'path'` MUST include the version part (e.g., `'/optimade/v1'` instead of `'/optimade'`) | Optional | `false` | `v1+`
+| `all_versioned_paths` | Whether to test all possible versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>The latter two being optional base URLs according to the specification. | Optional | `false` | `v1+`
 | `as_type` | Validate the request URL with the provided type, rather than scanning the entire implementation<br>Example values: 'structures', 'reference'. For a full list of values see `optimade-python-tools`. | Optional | - | `v1+`
 | `domain` | Domain for the OPTIMADE URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host` | `v1+`
 | `fail_fast` | Whether or not to exit and return a non-zero error code on first failure. | Optional | `false` | `v2+`
 | `index` | Whether or not this is an index meta-database | Optional | `false` | `v1+`
-| `path` | Path for the OPTIMADE (versioned) base URL - MUST start with `/`<br>_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade` or `/`, otherwise it MUST be versioned, e.g., the default value | Optional | `/v1` | `v1+`
+| `path` | Path for the OPTIMADE (versioned) base URL - MUST start with `/`<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation. | Optional | `/` | `v1+`
 | `port` | Port for the OPTIMADE URL | Optional | `5000` | `v1+`
 | `protocol` | Protocol for the OPTIMADE URL | Optional | `http` | `v1+`
 | `skip_optional` | Whether or not to skip tests for optional features. | Optional | `false` | `v2+`

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ This can be chosen using the input `validator_version`.
 | Input | Description | Usage | Default | Action version |
 | :---: |    :---     | :---: |  :---:  |      :---:     |
 | `all_versioned_paths` | Whether to test all possible versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>The latter two being optional base URLs according to the specification. | Optional | `false` | `v1+`
-| `as_type` | Validate the request URL with the provided type, rather than scanning the entire implementation<br>Example values: 'structures', 'reference'. For a full list of values see `optimade-python-tools`. | Optional | - | `v1+`
-| `domain` | Domain for the OPTIMADE URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host` | `v1+`
+| `as_type` | Validate the request URL with the provided type, rather than scanning the entire implementation.<br>Example values: `structures`, `reference`. For a full list of values see the [OPTIMADE Python tools documentation](https://www.optimade.org/optimade-python-tools/api_reference/validator/validator/#optimade.validator.validator.ImplementationValidator.__init__). | Optional | - | `v1+`
+| `domain` | Domain for the OPTIMADE URL (defaults to the GitHub Actions runner host). | Optional | `gh_actions_host` | `v1+`
 | `fail_fast` | Whether or not to exit and return a non-zero error code on first failure. | Optional | `false` | `v2+`
-| `index` | Whether or not this is an index meta-database | Optional | `false` | `v1+`
-| `path` | Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation` | Optional | `/` | `v1+`
-| `port` | Port for the OPTIMADE URL | Optional | `5000` | `v1+`
-| `protocol` | Protocol for the OPTIMADE URL | Optional | `http` | `v1+`
+| `index` | Whether or not this is an index meta-database. | Optional | `false` | `v1+`
+| `path` | Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`.<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation. | Optional | `/` | `v1+`
+| `port` | Port for the OPTIMADE URL. | Optional | `5000` | `v1+`
+| `protocol` | Protocol for the OPTIMADE URL. | Optional | `http` | `v1+`
 | `skip_optional` | Whether or not to skip tests for optional features. | Optional | `false` | `v2+`
 | `validator_version` | Full version of an OPTIMADE Python tools release to PyPI, e.g., `'v0.6.0'` or `'0.3.4'`, which hosts the `optimade-validator`. It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., `'master'` or `'5a5e903'`.<br>See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#git) for more information of what is allowed here.<br>Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.<br>Note, for the latest development version, choose `'master'`. | **Required** | `latest` | `v1+`
 | `verbosity` | The verbosity of the output.<br>`0`: minimalistic, `1`: informational, `2`+: debug | Optional | `1` | `v1+`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This can be chosen using the input `validator_version`.
 | `domain` | Domain for the OPTIMADE URL (defaults to the GitHub Actions runner host) | Optional | `gh_actions_host` | `v1+`
 | `fail_fast` | Whether or not to exit and return a non-zero error code on first failure. | Optional | `false` | `v2+`
 | `index` | Whether or not this is an index meta-database | Optional | `false` | `v1+`
-| `path` | Path for the OPTIMADE (versioned) base URL - MUST start with `/`<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation. | Optional | `/` | `v1+`
+| `path` | Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation` | Optional | `/` | `v1+`
 | `port` | Port for the OPTIMADE URL | Optional | `5000` | `v1+`
 | `protocol` | Protocol for the OPTIMADE URL | Optional | `http` | `v1+`
 | `skip_optional` | Whether or not to skip tests for optional features. | Optional | `false` | `v2+`

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
       Whether to test all possible versioned base URLs:
         /vMAJOR; /vMAJOR.MINOR; /vMAJOR.MINOR.PATCH
       If this is 'true', the input 'path' MUST exempt the version part (e.g., '/optimade' instead of '/optimade/v1').
-      If this is 'false', the input 'path' MUST include the version part (e.g., '/optimade/v1' instead of '/optimade').
+      If this is 'false', the action will only validate the implementation at 'path'.
     required: false
     default: false
 
@@ -38,9 +38,12 @@ inputs:
     default: false
 
   path:
-    description: Path of the OPTIMADE (versioned) base URL - MUST start with '/'
+    description: >
+      Path of the OPTIMADE (versioned) base URL - MUST start with '/'.
+      The path MUST NOT include the versioned part of the base URL.
+      Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation.
     required: false
-    default: /v1
+    default: /
 
   port:
     description: Port for the OPTIMADE URL

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,7 @@ inputs:
     description: >
       Whether to test all possible versioned base URLs:
         /vMAJOR; /vMAJOR.MINOR; /vMAJOR.MINOR.PATCH
-      If this is 'true', the input 'path' MUST exempt the version part (e.g., '/optimade' instead of '/optimade/v1').
-      If this is 'false', the action will only validate the implementation at 'path'.
+      The latter two being optional base URLs according to the specification.
     required: false
     default: false
 
@@ -23,7 +22,7 @@ inputs:
     required: false
 
   domain:
-    description: Domain for the OPTIMADE URL (defaults to the GH Actions runner host)
+    description: Domain for the OPTIMADE URL (defaults to the GH Actions runner host).
     required: false
     default: gh_actions_host
 
@@ -33,7 +32,7 @@ inputs:
     default: false
 
   index:
-    description: Whether or not this is an index meta-database
+    description: Whether or not this is an index meta-database.
     required: false
     default: false
 
@@ -46,11 +45,11 @@ inputs:
     default: /
 
   port:
-    description: Port for the OPTIMADE URL
+    description: Port for the OPTIMADE URL.
     required: false
 
   protocol:
-    description: Protocol for the OPTIMADE URL
+    description: Protocol for the OPTIMADE URL.
     required: false
     default: http
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
 
   path:
     description: >
-      Path of the OPTIMADE (versioned) base URL - MUST start with '/'.
+      Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`.
       The path MUST NOT include the versioned part of the base URL.
       Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation.
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,31 +85,36 @@ case ${INPUT_INDEX} in
         ;;
 esac
 
+# Run validator for unversioned base URL
+# For testing
+echo "run_validator: ${run_validator}${INPUT_PATH}${index}" > ./tests/.entrypoint-run_validator.txt
+sh -c "${run_validator}${INPUT_PATH}${index}"
 
+# Run validator for versioned base URL(s)
+if [ "${INPUT_PATH}" = "/" ]; then
+    filler="v"
+else
+    filler="/v"
+fi
 API_VERSION=($(python -c "from optimade import __api_version__; versions = [__api_version__.split('-')[0].split('+')[0].split('.')[0], '.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:2]), '.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:3])]; print(' '.join(versions))"))
 case ${INPUT_ALL_VERSIONED_PATHS} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         for version in "${API_VERSION[@]}"; do
-            if [ "${INPUT_PATH}" = "/" ]; then
-                # For testing
-                echo "run_validator: ${run_validator}${INPUT_PATH}v${version}${index}" > ./tests/.entrypoint-run_validator.txt
-                sh -c "${run_validator}${INPUT_PATH}v${version}${index}"
-            else
-                # For testing
-                echo "run_validator: ${run_validator}${INPUT_PATH}/v${version}${index}" > ./tests/.entrypoint-run_validator.txt
-                sh -c "${run_validator}${INPUT_PATH}/v${version}${index}"
-            fi
+            run_validator="${run_validator}${INPUT_PATH}${filler}${version}${index}"
+            # For testing
+            echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
+            sh -c "${run_validator}"
         done
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
-        run_validator="${run_validator}${INPUT_PATH}${index}"
+        run_validator="${run_validator}${INPUT_PATH}${filler}${API_VERSION[0]}${index}"
         # For testing
         echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
         sh -c "${run_validator}"
         ;;
     *)
         echo "Non-valid input for 'all versioned paths': ${INPUT_ALL_VERSIONED_PATHS}. Will use default (false)."
-        run_validator="${run_validator}${INPUT_PATH}${index}"
+        run_validator="${run_validator}${INPUT_PATH}${filler}${API_VERSION[0]}${index}"
         # For testing
         echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
         sh -c "${run_validator}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,10 +100,10 @@ API_VERSION=($(python -c "from optimade import __api_version__; versions = [__ap
 case ${INPUT_ALL_VERSIONED_PATHS} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         for version in "${API_VERSION[@]}"; do
-            run_validator="${run_validator}${INPUT_PATH}${filler}${version}${index}"
+            run_validator_version="${run_validator}${INPUT_PATH}${filler}${version}${index}"
             # For testing
-            echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
-            sh -c "${run_validator}"
+            echo "run_validator: ${run_validator_version}" > ./tests/.entrypoint-run_validator.txt
+            sh -c "${run_validator_version}"
         done
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,7 +86,7 @@ case ${INPUT_INDEX} in
 esac
 
 # Run validator for unversioned base URL
-# For testing
+# Echo line is for testing
 echo "run_validator: ${run_validator}${INPUT_PATH}${index}" > ./tests/.entrypoint-run_validator.txt
 sh -c "${run_validator}${INPUT_PATH}${index}"
 
@@ -101,22 +101,22 @@ case ${INPUT_ALL_VERSIONED_PATHS} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         for version in "${API_VERSION[@]}"; do
             run_validator_version="${run_validator}${INPUT_PATH}${filler}${version}${index}"
-            # For testing
-            echo "run_validator: ${run_validator_version}" > ./tests/.entrypoint-run_validator.txt
+            # Echo line is for testing
+            echo "run_validator: ${run_validator_version}" >> ./tests/.entrypoint-run_validator.txt
             sh -c "${run_validator_version}"
         done
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
         run_validator="${run_validator}${INPUT_PATH}${filler}${API_VERSION[0]}${index}"
-        # For testing
-        echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
+        # Echo line is for testing
+        echo "run_validator: ${run_validator}" >> ./tests/.entrypoint-run_validator.txt
         sh -c "${run_validator}"
         ;;
     *)
         echo "Non-valid input for 'all versioned paths': ${INPUT_ALL_VERSIONED_PATHS}. Will use default (false)."
         run_validator="${run_validator}${INPUT_PATH}${filler}${API_VERSION[0]}${index}"
-        # For testing
-        echo "run_validator: ${run_validator}" > ./tests/.entrypoint-run_validator.txt
+        # Echo line is for testing
+        echo "run_validator: ${run_validator}" >> ./tests/.entrypoint-run_validator.txt
         sh -c "${run_validator}"
         ;;
 esac

--- a/tests/test_all_versioned_paths.bats
+++ b/tests/test_all_versioned_paths.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load 'test_fixtures'
+
+@test "all_versioned_paths=False" {
+    export INPUT_ALL_VERSIONED_PATHS=False
+    run ${ENTRYPOINT_SH}
+    refute_output --partial "ERROR"
+
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
+}
+
+@test "all_versioned_paths=True" {
+    export INPUT_ALL_VERSIONED_PATHS=True
+    run ${ENTRYPOINT_SH}
+    refute_output --partial "ERROR"
+
+    OPTIMADE_VERSION=("v1.0" "v1.0.0")
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}${OPTIMADE_VERSION[0]}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}${OPTIMADE_VERSION[1]}"
+}
+
+@test "all_versioned_paths=invalid_value" {
+    # For an invalid value, it should fallback to the default (false)
+    export INPUT_ALL_VERSIONED_PATHS=invalid_value
+    run ${ENTRYPOINT_SH}
+    refute_output --partial "ERROR"
+
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
+}
+
+@test "all_versioned_paths=True for old spec v0.10.1" {
+    # Use OPTIMADE Python tools commit immediately prior to updating to
+    # OPTIMADE specification v1.0.0-rc2.
+    # The supported OPTIMADE specification version prior to v1.0.0-rc2 was v0.10.1.
+    export INPUT_ALL_VERSIONED_PATHS=True
+    export INPUT_VALIDATOR_VERSION=ad68951fc6089402392c6299e8206d19a570d060
+    run ${ENTRYPOINT_SH}
+    refute_output --partial "ERROR"
+
+    OPTIMADE_VERSION=("v0" "v0.10" "v0.10.1")
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}${OPTIMADE_VERSION[0]}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}${OPTIMADE_VERSION[1]}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}${OPTIMADE_VERSION[2]}"
+}

--- a/tests/test_as_type.bats
+++ b/tests/test_as_type.bats
@@ -2,14 +2,15 @@
 
 load 'test_fixtures'
 
-@test "Default as_type" {
+@test "Default as_type (general run with all defaults)" {
     # There isn't a default for as_type, so it shouldn't result in --as-type being set
     run ${ENTRYPOINT_SH}
     refute_output --partial "Validating as type: "
     refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
 }
 
 @test "as_type='structure'" {
@@ -19,20 +20,23 @@ load 'test_fixtures'
     assert_output --partial "Validating as type: ${VALID_AS_TYPE_VALUE}"
     refute_output --partial "ERROR"
 
-    TEST_FINAL_RUN_VALIDATOR="optimade-validator $( for i in {1..${INPUT_VERBOSITY}}; do echo '-v '; done; )--as-type ${VALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
+    TEST_BASE_RUN_VALIDATOR="optimade-validator $( for i in {1..${INPUT_VERBOSITY}}; do echo '-v '; done; )--as-type ${VALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
 }
 
 @test "as_type='non_valid_input' (invalid value, should fail with status 1 and message)" {
     INVALID_AS_TYPE_VALUE=non_valid_input
     export INPUT_AS_TYPE=${INVALID_AS_TYPE_VALUE}
+    # Don't use real entrypoint.sh here, since the error code comes from running the validator.
     run ${ENTRYPOINT_SH}
     assert_output --partial "Validating as type: ${INVALID_AS_TYPE_VALUE}"
     assert_failure 1
     assert_output --partial "${INVALID_AS_TYPE_VALUE} is not a valid type, must be one of "
 
-    TEST_FINAL_RUN_VALIDATOR="optimade-validator $( for i in {1..${INPUT_VERBOSITY}}; do echo '-v '; done; )--as-type ${INVALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
+    TEST_BASE_RUN_VALIDATOR="optimade-validator $( for i in {1..${INPUT_VERBOSITY}}; do echo '-v '; done; )--as-type ${INVALID_AS_TYPE_VALUE} ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
 }

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -6,29 +6,47 @@ if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
 fi
 
 # Absolute path to entrypoint.sh
-export ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/entrypoint.sh
+export REAL_ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/entrypoint.sh
+export ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/tests/.entrypoint.sh
 
 # Load BATS extensions (installed in ./tests/Dockerfile)
 load "${BATS_TEST_HELPERS}/bats-support/load.bash"
 load "${BATS_TEST_HELPERS}/bats-assert/load.bash"
 
-function setup() {
+function setup_file() {
     # Set all input parameter defaults
     export INPUT_ALL_VERSIONED_PATHS=false
     export INPUT_DOMAIN=gh_actions_host
+    export INPUT_FAIL_FAST=false
     export INPUT_INDEX=false
-    export INPUT_PATH=/v1
+    export INPUT_PATH=/
     export INPUT_PROTOCOL=http
+    export INPUT_SKIP_OPTIONAL=false
     export INPUT_VALIDATOR_VERSION=latest
     export INPUT_VERBOSITY=1
-    export INPUT_FAIL_FAST=false
-    export INPUT_SKIP_OPTIONAL=false
 
-    export TEST_FINAL_RUN_VALIDATOR="optimade-validator -v http://gh_actions_host/v1"
+    # Validator runs executed (with defaults)
+    export TEST_BASE_RUN_VALIDATOR="optimade-validator -v ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
+    export TEST_MAJOR_RUN_VALIDATOR="${TEST_BASE_RUN_VALIDATOR}v1"
 
+    # Clean "cache"
     rm -f ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    rm -f ${ENTRYPOINT_SH}
+
+    # Comment out "set -e" from entrypoint.sh in a new test entrypoint.sh
+    while IFS="" read -r line || [ -n "${line}" ]; do
+        if [[ "${line}" =~ ^set[[:blank:]]-e$ ]]; then
+            line="# ${line}"
+        fi
+        printf "%s\n" "${line}" >> ${ENTRYPOINT_SH}
+    done < ${REAL_ENTRYPOINT_SH}
+    chmod +x ${ENTRYPOINT_SH}
 }
 
 function teardown() {
     rm -f ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+}
+
+function teardown_file() {
+    rm -f ${ENTRYPOINT_SH}
 }

--- a/tests/test_validator_version.bats
+++ b/tests/test_validator_version.bats
@@ -9,7 +9,8 @@ load 'test_fixtures'
     refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
 }
 
 @test "validator_version='0.6.0'" {
@@ -19,7 +20,8 @@ load 'test_fixtures'
     refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v0"
 }
 
 @test "validator_version='v0.6.0'" {
@@ -30,7 +32,8 @@ load 'test_fixtures'
     refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v0"
 }
 
 @test "validator_version='master'" {
@@ -40,12 +43,14 @@ load 'test_fixtures'
     refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
 }
 
 @test "validator_version='0.0.0' (invalid value, should fail with status 1 and message)" {
     export INPUT_VALIDATOR_VERSION=0.0.0
-    run ${ENTRYPOINT_SH}
+    # For this test `set -e` is necessary, since this is what we are testing
+    run ${REAL_ENTRYPOINT_SH}
     assert_output --partial "Installing version $INPUT_VALIDATOR_VERSION of optimade"
     assert_failure 1
     assert_output --partial "ERROR"

--- a/tests/test_verbosity.bats
+++ b/tests/test_verbosity.bats
@@ -9,7 +9,8 @@ load 'test_fixtures'
     refute_output --partial "ERROR"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
 }
 
 @test "verbosity=0" {
@@ -19,9 +20,10 @@ load 'test_fixtures'
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
     refute_output --partial "ERROR"
 
-    TEST_FINAL_RUN_VALIDATOR="optimade-validator ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
+    TEST_BASE_RUN_VALIDATOR="optimade-validator ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
 }
 
 @test "verbosity='test' (invalid value, should use default instead)" {
@@ -33,7 +35,8 @@ load 'test_fixtures'
     assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
 }
 
 @test "verbosity=3" {
@@ -43,7 +46,8 @@ load 'test_fixtures'
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
     refute_output --partial "ERROR"
 
-    TEST_FINAL_RUN_VALIDATOR="optimade-validator -v -v -v ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
+    TEST_BASE_RUN_VALIDATOR="optimade-validator -v -v -v ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
-    assert_output "run_validator: ${TEST_FINAL_RUN_VALIDATOR}"
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
 }


### PR DESCRIPTION
Closes #31 

Change the validator action to check the mandatory base URLs:
- Unversioned base URL.
- Major-versioned base URL.

The input `all versioned paths` will now simply add validation for the Major.Minor-versioned base URL as well as the Major.Minor.Patch-versioned base URL.

The input `path` MUST now point to the unversioned OPTIMADE base URL.