### PR TITLE
Add `create_outputs` and `results` output

### DIFF
--- a/.github/workflows/ci_helper.py
+++ b/.github/workflows/ci_helper.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+
+def check_output(expected_keys: list):
+    expected_results_keys = ["success_count", "failure_count"]  # not complete list
+    results = json.loads(os.getenv("RESULTS"))
+
+    assert len(results) == len(expected_keys)
+
+    for key in expected_keys:
+        assert key in results
+        for sub_key in expected_results_keys:
+            assert sub_key in results[key]
+
+
+if __name__ == "__main__":
+    commands = ["default", "all_versioned_paths"]
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cmd", help="Command to run.", type=str, choices=commands)
+    args = parser.parse_args()
+
+    if args.cmd == "default":
+        check_output(["unversioned", "v1"])
+    elif args.cmd == "all_versioned_paths":
+        check_output(["unversioned", "v1", "v1.0", "v1.0.0"])
+    else:
+        exit(f"Wrong command, it must be one of {commands}")

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -12,7 +12,6 @@ jobs:
   validator_regular:
     runs-on: ubuntu-latest
     name: Regular server
-
     steps:
       - uses: actions/checkout@v2
 
@@ -32,7 +31,6 @@ jobs:
   validator_index:
     runs-on: ubuntu-latest
     name: Index server
-
     steps:
       - uses: actions/checkout@v2
 
@@ -53,7 +51,6 @@ jobs:
   all_versioned_paths:
     runs-on: ubuntu-latest
     name: All versioned paths for regular server
-
     steps:
       - uses: actions/checkout@v2
 
@@ -81,7 +78,6 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     name: Run BATS test suite for entrypoint.sh
-
     steps:
       - uses: actions/checkout@v2
 
@@ -94,7 +90,6 @@ jobs:
   validator_version:
     runs-on: ubuntu-latest
     name: Use validator from git commit sha
-
     steps:
       - uses: actions/checkout@v2
 
@@ -115,7 +110,6 @@ jobs:
   validator_version_fail:
     runs-on: ubuntu-latest
     name: Use validator with wrong version
-
     steps:
       - uses: actions/checkout@v2
 
@@ -140,3 +134,68 @@ jobs:
         run: |
           echo "Outcome: ${{ steps.action.outcome }} (not 'failure'), Conclusion: ${{ steps.action.conclusion }} (not 'success')"
           exit 1
+
+  results_output:
+    runs-on: ubuntu-latest
+    name: Retrieve and check validator results
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up and run regular server
+        run: |
+          git clone --recurse-submodules https://github.com/Materials-Consortia/optimade-python-tools
+          docker-compose -f ./optimade-python-tools/docker-compose.yml up optimade &
+          .github/workflows/wait_for_it.sh localhost:3213 -t 120
+          sleep 15
+
+      - name: Run action to retrieve output
+        id: action
+        uses: ./
+        with:
+          port: 3213
+          path: /
+          create output: true
+
+      - name: Check "default" output
+        env:
+          RESULTS: ${{ steps.action.outputs.results }}
+        run: |
+          import json, os
+          expected_keys = ["unversioned", "v1"]  # complete list
+          expected_results_keys = ["success_count", "failure_count"]  # not complete list
+          results = json.loads(os.getenv("RESULTS", {}))
+          assert len(results) == len(expected_keys)
+          for key in expected_keys:
+            assert key in results
+            for sub_key in expected_results_keys:
+              assert sub_key in results[key]
+        shell: python
+
+      - name: Run action with all_versioned_paths to retrieve output
+        id: action_all
+        uses: ./
+        with:
+          port: 3213
+          path: /
+          create output: true
+          all versioned paths: true
+
+      - name: Check "all_versioned_paths" output
+        env:
+          RESULTS: ${{ steps.action_all.outputs.results }}
+        run: |
+          import json, os
+          expected_keys = ["unversioned", "v1", "v1.0", "v1.0.0"]  # complete list
+          expected_results_keys = ["success_count", "failure_count"]  # not complete list
+          results = json.loads(os.getenv("RESULTS", {}))
+          assert len(results) == len(expected_keys)
+          for key in expected_keys:
+            assert key in results
+            for sub_key in expected_results_keys:
+              assert sub_key in results[key]
+        shell: python

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Check "default" output
         env:
-          RESULTS: ${{ steps.action.outputs.results }}
+          RESULTS: "${{ steps.action.outputs.results }}"
         run: python .github/workflows/ci_helper.py default
 
       - name: Run action with all_versioned_paths to retrieve output
@@ -177,5 +177,5 @@ jobs:
 
       - name: Check "all_versioned_paths" output
         env:
-          RESULTS: ${{ steps.action_all.outputs.results }}
+          RESULTS: "${{ steps.action_all.outputs.results }}"
         run: python .github/workflows/ci_helper.py all_versioned_paths

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Check "default" output
         env:
-          RESULTS: ${{ steps.action.outputs.results }}
+          RESULTS: ${{ fromJson(steps.action.outputs.results) }}
         run: python .github/workflows/ci_helper.py default
 
       - name: Run action with all_versioned_paths to retrieve output
@@ -177,5 +177,5 @@ jobs:
 
       - name: Check "all_versioned_paths" output
         env:
-          RESULTS: ${{ steps.action_all.outputs.results }}
+          RESULTS: ${{ fromJson(steps.action_all.outputs.results) }}
         run: python .github/workflows/ci_helper.py all_versioned_paths

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Check "default" output
         env:
-          RESULTS: ${{ fromJson(steps.action.outputs.results) }}
+          RESULTS: ${{ toJson(steps.action.outputs.results) }}
         run: python .github/workflows/ci_helper.py default
 
       - name: Run action with all_versioned_paths to retrieve output
@@ -177,5 +177,5 @@ jobs:
 
       - name: Check "all_versioned_paths" output
         env:
-          RESULTS: ${{ fromJson(steps.action_all.outputs.results) }}
+          RESULTS: ${{ toJson(steps.action_all.outputs.results) }}
         run: python .github/workflows/ci_helper.py all_versioned_paths

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Check "default" output
         env:
-          RESULTS: ${{ toJson(steps.action.outputs.results) }}
+          RESULTS: ${{ steps.action.outputs.results }}
         run: python .github/workflows/ci_helper.py default
 
       - name: Run action with all_versioned_paths to retrieve output
@@ -177,5 +177,5 @@ jobs:
 
       - name: Check "all_versioned_paths" output
         env:
-          RESULTS: ${{ toJson(steps.action_all.outputs.results) }}
+          RESULTS: ${{ steps.action_all.outputs.results }}
         run: python .github/workflows/ci_helper.py all_versioned_paths

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -168,7 +168,7 @@ jobs:
           import json, os
           expected_keys = ["unversioned", "v1"]  # complete list
           expected_results_keys = ["success_count", "failure_count"]  # not complete list
-          results = json.loads(os.getenv("RESULTS", {}))
+          results = json.loads(os.getenv("RESULTS"))
           assert len(results) == len(expected_keys)
           for key in expected_keys:
             assert key in results
@@ -192,7 +192,7 @@ jobs:
           import json, os
           expected_keys = ["unversioned", "v1", "v1.0", "v1.0.0"]  # complete list
           expected_results_keys = ["success_count", "failure_count"]  # not complete list
-          results = json.loads(os.getenv("RESULTS", {}))
+          results = json.loads(os.getenv("RESULTS"))
           assert len(results) == len(expected_keys)
           for key in expected_keys:
             assert key in results

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -164,17 +164,7 @@ jobs:
       - name: Check "default" output
         env:
           RESULTS: ${{ steps.action.outputs.results }}
-        run: |
-          import json, os
-          expected_keys = ["unversioned", "v1"]  # complete list
-          expected_results_keys = ["success_count", "failure_count"]  # not complete list
-          results = json.loads(os.getenv("RESULTS"))
-          assert len(results) == len(expected_keys)
-          for key in expected_keys:
-            assert key in results
-            for sub_key in expected_results_keys:
-              assert sub_key in results[key]
-        shell: python
+        run: python .github/workflows/ci_helper.py default
 
       - name: Run action with all_versioned_paths to retrieve output
         id: action_all
@@ -188,14 +178,4 @@ jobs:
       - name: Check "all_versioned_paths" output
         env:
           RESULTS: ${{ steps.action_all.outputs.results }}
-        run: |
-          import json, os
-          expected_keys = ["unversioned", "v1", "v1.0", "v1.0.0"]  # complete list
-          expected_results_keys = ["success_count", "failure_count"]  # not complete list
-          results = json.loads(os.getenv("RESULTS"))
-          assert len(results) == len(expected_keys)
-          for key in expected_keys:
-            assert key in results
-            for sub_key in expected_results_keys:
-              assert sub_key in results[key]
-        shell: python
+        run: python .github/workflows/ci_helper.py all_versioned_paths

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM python:3.8
 
 RUN echo $(ip route | awk '{print $3}') > /docker_host_ip
 
+COPY helper.py /helper.py
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,13 @@ inputs:
     required: false
     default: false
 
+  create output:
+    description: >
+      Use `-j/--json` option for `optimade-validator`.
+      This will overwrite the `verbosity` input parameter, since it will be set to `-1` when using the `-j/--json` option.
+    required: false
+    default: false
+
   path:
     description: >
       Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`.
@@ -72,6 +79,14 @@ inputs:
     description: The verbosity of the output
     required: false
     default: 1
+
+outputs:
+
+  results:
+    description: >
+      JSON object with results overview from `optimade-validator`.
+      This is equivalent to passing `-j/--json` to `optimade-validator`.
+      NOTE: This is only set if `create output` is set to `True`.
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,6 +158,6 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 # Create output 'results'
 RESULTS=$(python helper.py results)
-echo "::set-output name=results::${RESULTS//\"/\\\"}"
+echo "::set-output name=results::${RESULTS}"
 
 exit ${EXIT_CODE}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,10 +34,14 @@ run_validator="optimade-validator"
 
 case ${INPUT_CREATE_OUTPUT} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
-        echo "Will create JSON output, retrievable through '\${{ steps.<step_id>.outputs.results }}'."
-        echo "Verbosity level will be reset to '-1'."
-        run_validator="${run_validator} --json"
-        INPUT_VERBOSITY=-1
+        if ! ( [ ${PACKAGE_VERSION[0]} -eq 0 ] && [ ${PACKAGE_VERSION[1]} -lt 13 ] ); then
+            echo "Will create JSON output, retrievable through '\${{ steps.<step_id>.outputs.results }}'."
+            echo "Verbosity level will be reset to '-1'."
+            run_validator="${run_validator} --json"
+            INPUT_VERBOSITY=-1
+        else
+            echo "create_output not supported for the chosen validator_version (${INPUT_VALIDATOR_VERSION})"
+        fi
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
         ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,13 +34,14 @@ run_validator="optimade-validator"
 
 case ${INPUT_CREATE_OUTPUT} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
-        if ! ( [ ${PACKAGE_VERSION[0]} -eq 0 ] && [ ${PACKAGE_VERSION[1]} -lt 13 ] ); then
+        if [ ${PACKAGE_VERSION[0]} -eq 0 ] && ( ( [ ${PACKAGE_VERSION[1]} -eq 12 ] && [ ${PACKAGE_VERSION[2]} -lt 1 ] ) || [ ${PACKAGE_VERSION[1]} -lt 12 ] ); then
+            # optimade < 0.12.1
+            echo "create_output not supported for the chosen validator_version (${INPUT_VALIDATOR_VERSION})"
+        else
             echo "Will create JSON output, retrievable through '\${{ steps.<step_id>.outputs.results }}'."
             echo "Verbosity level will be reset to '-1'."
             run_validator="${run_validator} --json"
             INPUT_VERBOSITY=-1
-        else
-            echo "create_output not supported for the chosen validator_version (${INPUT_VALIDATOR_VERSION})"
         fi
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,7 +110,7 @@ esac
 # Run validator for unversioned base URL
 # Echo line is for testing
 echo "run_validator: ${run_validator}${INPUT_PATH}${index}" > ./tests/.entrypoint-run_validator.txt
-sh -c "${run_validator}${INPUT_PATH}${index}" | tee "unversioned.json"
+sh -c "${run_validator}${INPUT_PATH}${index}" | tee -p exit-nopipe "unversioned.json"
 
 # Run validator for versioned base URL(s)
 if [ "${INPUT_PATH}" = "/" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ else
 fi
 
 # Check optimade-python-tools version is >0.10
-PACKAGE_VERSION=($(python -c "from optimade import __version__; print(__version__.replace('.', ' '))"))
+PACKAGE_VERSION=($(python helper.py package-version))
 
 if [ ${PACKAGE_VERSION[0]} -eq 0 ] && [ ${PACKAGE_VERSION[1]} -lt 10 ]; then
     echo "Incompatible validator version requested ${INPUT_VALIDATOR_VERSION}, please use >=0.10."
@@ -123,7 +123,7 @@ if [ "${INPUT_PATH}" = "/" ]; then
 else
     filler="/v"
 fi
-API_VERSION=($(python -c "from optimade import __api_version__; versions = [__api_version__.split('-')[0].split('+')[0].split('.')[0], '.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:2]), '.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:3])]; print(' '.join(versions))"))
+API_VERSION=($(python helper.py api-versions))
 case ${INPUT_ALL_VERSIONED_PATHS} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         for version in "${API_VERSION[@]}"; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,6 +158,6 @@ EXIT_CODE=${PIPESTATUS[0]}
 
 # Create output 'results'
 RESULTS=$(python helper.py results)
-echo "::set-output name=results::${RESULTS}"
+echo "::set-output name=results::${RESULTS//\"/\\\"}"
 
 exit ${EXIT_CODE}

--- a/helper.py
+++ b/helper.py
@@ -26,6 +26,31 @@ def delete_files(path):
         os.remove(filename)
 
 
+def optimade_api_version():
+    """Print OPTIMADE API version supported in currently installed optimade package as input for shell array"""
+    try:
+        from optimade import __api_version__
+    except ImportError:
+        exit("optimade MUST be installed to run 'api-version'")
+
+    versions = [
+        __api_version__.split('-')[0].split('+')[0].split('.')[0],
+        '.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:2]),
+        '.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:3]),
+    ]
+    print(' '.join(versions))
+
+
+def optimade_package_version():
+    """Print optimade package version in currently installed environment as input for shell array"""
+    try:
+        from optimade import __version__
+    except ImportError:
+        exit("optimade MUST be installed to run 'package-version'")
+
+    print(__version__.split('-')[0].split('+')[0].replace('.', ' '))
+
+
 if __name__ == "__main__":
     commands = ["api-versions", "package-version", "results"]
 
@@ -34,9 +59,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.cmd == "api-versions":
-        pass
+        optimade_api_version()
     elif args.cmd == "package-version":
-        pass
+        optimade_package_version()
     elif args.cmd == "results":
         create_output()
         delete_files("*.json")

--- a/helper.py
+++ b/helper.py
@@ -23,7 +23,12 @@ def delete_files(path):
     import os
 
     for filename in iglob(path):
-        os.remove(filename)
+        if os.path.isfile(filename):
+            os.remove(filename)
+        else:
+            import warnings
+
+            warnings.warn(f"{filename!r} does not seem to be a file, did not remove it.")
 
 
 def optimade_api_version():

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+from glob import iglob
+
+
+def create_output():
+    """Create single JSON object from found JSON files"""
+    import json
+
+    results = {}
+    for filename in iglob("*.json"):
+        name = filename[:-len(".json")]
+        with open(filename) as handle:
+            try:
+                results[name] = json.load(handle)
+            except json.JSONDecodeError:
+                continue
+    print(json.dumps(results))
+
+
+def delete_files(path):
+    """Delete files"""
+    import os
+
+    for filename in iglob(path):
+        os.remove(filename)
+
+
+if __name__ == "__main__":
+    commands = ["api-versions", "package-version", "results"]
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cmd", help="Command to run.", type=str, choices=commands)
+    args = parser.parse_args()
+
+    if args.cmd == "api-versions":
+        pass
+    elif args.cmd == "package-version":
+        pass
+    elif args.cmd == "results":
+        create_output()
+        delete_files("*.json")
+    else:
+        exit(f"Wrong command, it must be one of {commands}")

--- a/helper.py
+++ b/helper.py
@@ -15,7 +15,7 @@ def create_output():
                 results[name] = json.load(handle)
             except json.JSONDecodeError:
                 continue
-    print(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=None, separators=(",", ":")))
 
 
 def delete_files(path):

--- a/helper.py
+++ b/helper.py
@@ -15,11 +15,11 @@ def create_output():
                 results[name] = json.load(handle)
             except json.JSONDecodeError:
                 continue
-    print(json.dumps(results))
+    print(json.dumps(results, indent=2))
 
 
 def delete_files(path):
-    """Delete files"""
+    """Deletes all files matching the pattern passed in `path`."""
     import os
 
     for filename in iglob(path):

--- a/tests/test_create_output.bats
+++ b/tests/test_create_output.bats
@@ -3,7 +3,6 @@
 load 'test_fixtures'
 
 @test "create_output=True" {
-    skip "Unskip when 'optimade' has made a new release (newer than v0.12.0)"
     export INPUT_CREATE_OUTPUT=True
     run ${ENTRYPOINT_SH}
     assert_output --partial "Will create JSON output"

--- a/tests/test_create_output.bats
+++ b/tests/test_create_output.bats
@@ -3,7 +3,7 @@
 load 'test_fixtures'
 
 @test "create_output=True" {
-    skip "Unskip when 'optimade' has been made a new release (newer than v0.12.0)"
+    skip "Unskip when 'optimade' has made a new release (newer than v0.12.0)"
     export INPUT_CREATE_OUTPUT=True
     run ${ENTRYPOINT_SH}
     assert_output --partial "Will create JSON output"

--- a/tests/test_create_output.bats
+++ b/tests/test_create_output.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load 'test_fixtures'
+
+@test "create_output=True" {
+    export INPUT_CREATE_OUTPUT=True
+    run ${ENTRYPOINT_SH}
+    assert_output --partial "Will create JSON output"
+    assert_output --partial "Using verbosity level: -1"
+    refute_output --partial "ERROR"
+    refute_output --partial "Non-valid input for 'verbosity'"
+
+    TEST_BASE_RUN_VALIDATOR="optimade-validator --json ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
+}
+
+@test "create_output='test' (invalid value, should use default instead)" {
+    export INPUT_CREATE_OUTPUT=test
+    run ${ENTRYPOINT_SH}
+    assert_output --partial "Non-valid input for 'create_output': ${INPUT_CREATE_OUTPUT}. Will use default (false)."
+    assert_output --partial "Using verbosity level: ${INPUT_VERBOSITY}"
+    refute_output --partial "ERROR"
+    refute_output --partial "Non-valid input for 'verbosity'"
+
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
+}

--- a/tests/test_create_output.bats
+++ b/tests/test_create_output.bats
@@ -3,6 +3,7 @@
 load 'test_fixtures'
 
 @test "create_output=True" {
+    skip "Unskip when 'optimade' has been made a new release (newer than v0.12.0)"
     export INPUT_CREATE_OUTPUT=True
     run ${ENTRYPOINT_SH}
     assert_output --partial "Will create JSON output"
@@ -21,6 +22,22 @@ run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
     run ${ENTRYPOINT_SH}
     assert_output --partial "Non-valid input for 'create_output': ${INPUT_CREATE_OUTPUT}. Will use default (false)."
     assert_output --partial "Using verbosity level: ${INPUT_VERBOSITY}"
+    refute_output --partial "ERROR"
+    refute_output --partial "Non-valid input for 'verbosity'"
+
+    run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
+    assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
+run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
+}
+
+@test "create_output=True (with validator_version that hasn't got the '--json' option)" {
+    export INPUT_CREATE_OUTPUT=True
+    export INPUT_VALIDATOR_VERSION=0.12.0
+    run ${ENTRYPOINT_SH}
+    assert_output --partial "create_output not supported for the chosen validator_version (${INPUT_VALIDATOR_VERSION})"
+    assert_output --partial "Using verbosity level: 1"
+    refute_output --partial "Will create JSON output"
+    refute_output --partial "Using verbosity level: -1"
     refute_output --partial "ERROR"
     refute_output --partial "Non-valid input for 'verbosity'"
 

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -23,7 +23,7 @@ function setup_file() {
     export INPUT_PATH=/
     export INPUT_PROTOCOL=http
     export INPUT_SKIP_OPTIONAL=false
-    export INPUT_VALIDATOR_VERSION=master
+    export INPUT_VALIDATOR_VERSION=latest
     export INPUT_VERBOSITY=1
 
     # Validator runs executed (with defaults)

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -19,10 +19,11 @@ function setup_file() {
     export INPUT_DOMAIN=gh_actions_host
     export INPUT_FAIL_FAST=false
     export INPUT_INDEX=false
+    export INPUT_CREATE_OUTPUT=false
     export INPUT_PATH=/
     export INPUT_PROTOCOL=http
     export INPUT_SKIP_OPTIONAL=false
-    export INPUT_VALIDATOR_VERSION=latest
+    export INPUT_VALIDATOR_VERSION=master
     export INPUT_VERBOSITY=1
 
     # Validator runs executed (with defaults)

--- a/tests/test_verbosity.bats
+++ b/tests/test_verbosity.bats
@@ -7,6 +7,7 @@ load 'test_fixtures'
     run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
     refute_output --partial "ERROR"
+    refute_output --partial "Non-valid input for 'verbosity'"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
     assert_output "run_validator: ${TEST_BASE_RUN_VALIDATOR}
@@ -19,6 +20,7 @@ run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
     run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
     refute_output --partial "ERROR"
+    refute_output --partial "Non-valid input for 'verbosity'"
 
     TEST_BASE_RUN_VALIDATOR="optimade-validator ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
@@ -31,7 +33,7 @@ run_validator: ${TEST_BASE_RUN_VALIDATOR}v1"
     VERBOSITY_DEFAULT=${INPUT_VERBOSITY}  # Use value from 'test_fixtures.bash'
     export INPUT_VERBOSITY=${INVALID_VERBOSITY_VALUE}
     run ${ENTRYPOINT_SH}
-    assert_output --partial "Non-valid input for 'verbosity': ${INVALID_VERBOSITY_VALUE}. Will use default (1)." ]
+    assert_output --partial "Non-valid input for 'verbosity': ${INVALID_VERBOSITY_VALUE}. Will use default (1)."
     assert_output --partial "Using verbosity level: ${VERBOSITY_DEFAULT}"
 
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt
@@ -45,6 +47,7 @@ run_validator: ${TEST_MAJOR_RUN_VALIDATOR}"
     run ${ENTRYPOINT_SH}
     assert_output --partial "Using verbosity level: ${VALID_VERBOSITY_VALUE}"
     refute_output --partial "ERROR"
+    refute_output --partial "Non-valid input for 'verbosity'"
 
     TEST_BASE_RUN_VALIDATOR="optimade-validator -v -v -v ${INPUT_PROTOCOL}://${INPUT_DOMAIN}${INPUT_PATH}"
     run cat ${DOCKER_BATS_WORKDIR}/tests/.entrypoint-run_validator.txt


### PR DESCRIPTION
Closes #41.

The new output will be a JSON object of JSON objects.
The outer objects' keys represent the base URL, it can either be:
- `"unversioned"`
- `"vMAJOR"`
- `"vMAJOR.MINOR"`
- `"vMAJOR.MINOR.PATCH"`
where MAJOR, MINOR, and PATCH represent the current OPTIMADE API version.

New tests to make sure the `-j/--json` option is used when `create_outputs` is `True`.

New CI tests to make sure the output `results` is correctly created, with the correct content depending on the base URLs checked.