### PR TITLE
Remove Docker container after test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Steps to setup your test environment:
 Now you can run
 
 ```sh
-docker run -i -v "$(pwd):/code" --workdir /code/tests optimade_bats .
+docker run --rm -it -v "$(pwd):/code" --workdir /code optimade_bats ./tests
 ```
 
 or

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,7 +22,7 @@ if [ -n "$1" ]; then
 fi
 
 if [ "${CI}" == "true" ]; then
-    docker run -i -v "$(pwd):/code" --workdir /code ${DOCKER_BATS_IMAGE_NAME} ${DOCKER_BATS_TEST_PATH}
+    docker run --rm -i -v "$(pwd):/code" --workdir /code ${DOCKER_BATS_IMAGE_NAME} ${DOCKER_BATS_TEST_PATH}
 else
-    docker run -it -v "$(pwd):/code" --workdir /code ${DOCKER_BATS_IMAGE_NAME} ${DOCKER_BATS_TEST_PATH}
+    docker run --rm -it -v "$(pwd):/code" --workdir /code ${DOCKER_BATS_IMAGE_NAME} ${DOCKER_BATS_TEST_PATH}
 fi


### PR DESCRIPTION
Add `--rm` to `docker run` commands, which will remove the Docker container after the tests have run.

The README has been updated as well, after checking whether the default `docker run` command worked - it did not. Now it does.