### PR TITLE
Update Dockerfile to fix `ip` binary issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.9
+FROM python:3.9-slim-buster
 
-RUN set -o pipefail \
-    echo $(ip route | awk '{print $3}') > /docker_host_ip
+RUN apt update && apt install -y iproute2
+CMD [ "bash" ]
+RUN set -o pipefail && echo $(ip route | awk '{print $3}') > /docker_host_ip
 
 COPY helper.py /helper.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.9-slim-buster
 
 RUN apt update && apt install -y iproute2
-CMD [ "bash" ]
-RUN set -o pipefail && echo $(ip route | awk '{print $3}') > /docker_host_ip
+RUN ["/bin/bash", "-c", "set -o pipefail && ip route | awk '{print $3}' > docker_host_ip"]
 
 COPY helper.py /helper.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9
 
-RUN echo $(ip route | awk '{print $3}') > /docker_host_ip
+RUN set -o pipefail \
+    echo $(ip route | awk '{print $3}') > /docker_host_ip
 
 COPY helper.py /helper.py
 


### PR DESCRIPTION
Fixes #70.

- [X] Add pipefail command to Dockerfile.
- [x] Set specific docker image and install minimum dependencies.