### PR TITLE
Fix workflow and python-version task

### DIFF
--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -42,7 +42,7 @@ jobs:
           if [[ "${line}" =~ ^invoke.*$ ]]; then
             invoke="${line}"
           fi
-        done < requirements_docs.txt
+        done < requirements.txt
 
         pip install ${invoke}
 

--- a/tasks.py
+++ b/tasks.py
@@ -82,11 +82,17 @@ def check_dockerfile_python_version(_):
 
     update_file(
         TOP_DIR / ".github" / "workflows" / "ci_tests.yml",
-        (r"PYTHON_VERSION: 3\.[0-9]+", f"PYTHON_VERSION: {dockerfile_python_version}"),
+        (
+            r"PYTHON_VERSION: 3\.[0-9]+.*",
+            f"PYTHON_VERSION: {dockerfile_python_version}",
+        ),
     )
     update_file(
         TOP_DIR / "pyproject.toml",
-        (r"python_version = \".*\"", f'python_version = "{dockerfile_python_version}"'),
+        (
+            r"python_version = \".*\"",
+            f"python_version = \"{'.'.join(dockerfile_python_version.split('.')[:2])}\"",
+        ),
     )
 
     print(


### PR DESCRIPTION
Fixes #80 

MyPy only accepts python version up to a minor specification, i.e., x.y,
not x.y.z. Since Dependabot might update to a full versioned Python
Docker image the task needs to only put the first two version numbers in
the config file for MyPy.

The workflow referenced a requirements file that doesn't exist.