### PR TITLE
Use Python tools logic for checking PR body

### DIFF
--- a/.github/workflows/ci_updated_master.yml
+++ b/.github/workflows/ci_updated_master.yml
@@ -34,7 +34,8 @@ jobs:
         git fetch origin
 
         LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
-        if [ "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8)" == "$(cat .github/utils/single_dependency_pr_body.txt | head -8)" ]; then
+        cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
+        if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
           # The dependency branch has just been merged into ${DEFAULT_REPO_BRANCH}
           # The dependency branch should be reset to ${DEFAULT_REPO_BRANCH}
           echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."


### PR DESCRIPTION
Update to use the same logic as for OPTIMADE Python tools when comparing
PR body for checking whether to reset `ci/dependabot-updates` or just
merge `master` into it.