### PR TITLE
Build BATS Docker image locally

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -149,14 +149,39 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     name: Run BATS test suite for entrypoint.sh
+
+    env:
+      # Latest BATS version
+      # This should manually be updated when a new version is released
+      # Tries to match the latest Docker tag for the BATS image at:
+      # https://hub.docker.com/r/bats/bats/tags
+      BATS_VERSION: '1.11.0'
+      # The latest alpine version with Python3.9
+      # For more information use the alpine package search:
+      # https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.15
+      BASH_DOCKER_TAG: alpine3.15
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout bats-core/bats-core
+        uses: actions/checkout@v4
+        with:
+          repository: bats-core/bats-core
+          path: bats-core
+
+      - name: Build BATS Docker image
+        run: docker build -t materials-consortia/bats:${{ env.BATS_VERSION }} --build-arg bashver=${{ env.BASH_DOCKER_TAG }} ./bats-core
+
+      - name: Checkout the local repository
+        uses: actions/checkout@v4
+        with:
+          path: main
 
       - name: Build BATS environment
-        run: docker build -t optimade_bats ./tests
+        run: docker build -t optimade_bats ./main/tests
 
       - name: Run BATS tests
         run: ./run_tests.sh
+        working-directory: main
 
   validator_version:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.entrypoint-run_validator.txt
 /tests/.entrypoint.sh
 *v*.json
+
+.*_cache/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 -->
 # GitHub Action - OPTIMADE validator
 
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-v2-undefined.svg?logo=github&logoColor=white&style=flat)](https://github.com/marketplace/actions/optimade-validator)
@@ -10,8 +11,8 @@ Latest versions:
 
 | Used tag | Effective version |
 | :---: | :---: |
-| `v2` | [`v2.7.0`](https://github.com/Materials-Consortia/optimade-validator-action/releases/tag/v2.7.0)
-| `v1` | [`v1.2.0`](https://github.com/Materials-Consortia/optimade-validator-action/releases/tag/v1.2.0)
+| `v2` | [`v2.7.0`](https://github.com/Materials-Consortia/optimade-validator-action/releases/tag/v2.7.0) |
+| `v1` | [`v1.2.0`](https://github.com/Materials-Consortia/optimade-validator-action/releases/tag/v1.2.0) |
 
 ## Example usage
 
@@ -69,19 +70,19 @@ This can be chosen using the input `validator version`.
 
 | Input | Description | Usage | Default | Action version |
 | :---: |    :---     | :---: |  :---:  |      :---:     |
-| `all versioned paths` | Whether to test the optional versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>If `false`, only the mandatory /vMAJOR URL will be tested. | Optional | `false` | `v1+`
-| `validate unversioned path` | Whether to validate the input URL as a full OPTIMADE implementation without appending any version.<br><br>This action assumes that the 'path' parameter will contain an unversioned URL. As it is not mandatory to run a full OPTIMADE implementation from the unversioned URL, by default, this action will not perform any validation of this URL, beyond checking the mandatory `/versions` endpoint. | Optional | `false` | `v2.3+`
-| `as type` | Validate the request URL with the provided type, rather than scanning the entire implementation.<br>Example values: `structures`, `reference`. For a full list of values see the [OPTIMADE Python tools documentation](https://www.optimade.org/optimade-python-tools/api_reference/validator/validator/#optimade.validator.validator.ImplementationValidator.__init__).<br>It is expected that `path` points to the exact endpoint to be validated. You must include any versions or similar if desired, as the `path` will be used as given.<br>**NB**: This input takes precedence over `all versioned paths`, `validate unversioned path`, and `index`, meaning these will be _ignored_ if `as type` is defined. | Optional | - | `v1+`
-| `domain` | Domain for the OPTIMADE URL (defaults to the GitHub Actions runner host). | Optional | `gh_actions_host` | `v1+`
-| `fail fast` | Whether or not to exit and return a non-zero error code on first failure. | Optional | `false` | `v2+`
-| `index` | Whether or not this is an index meta-database. | Optional | `false` | `v1+`
-| `path` | Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`.<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation (**except** if `as type` is defined, then `path` should define the full path to the endpoint to be validated, including also the versioned part if desired, e.g., `/v1.0/structures`). | Optional | `/` | `v1+`
-| `port` | Port for the OPTIMADE URL. | Optional | `5000` | `v1+`
-| `protocol` | Protocol for the OPTIMADE URL. | Optional | `http` | `v1+`
-| `skip optional` | Whether or not to skip tests for optional features. | Optional | `false` | `v2+`
-| `minimal` | Whether or not to reduce the validation to a minimal test set that only checks responses and not filters. | Optional | `false` | `v2.4.1+`
-| `validator version` | Full version of an OPTIMADE Python tools release to PyPI, e.g., `'v0.6.0'` or `'0.3.4'`, which hosts the `optimade-validator`. It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., `'master'` or `'5a5e903'`.<br>See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#git) for more information of what is allowed here.<br>Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.<br>Note, for the latest development version, choose `'master'`. | **Required** | `latest` | `v1+`
-| `verbosity` | The verbosity of the output.<br>`0`: minimalistic, `1`: informational, `2`+: debug | Optional | `1` | `v1+`
+| `all versioned paths` | Whether to test the optional versioned base URLs:<br><br>/vMAJOR<br>/vMAJOR.MINOR<br>/vMAJOR.MINOR.PATCH<br><br>If `false`, only the mandatory /vMAJOR URL will be tested. | Optional | `false` | `v1+` |
+| `validate unversioned path` | Whether to validate the input URL as a full OPTIMADE implementation without appending any version.<br><br>This action assumes that the 'path' parameter will contain an unversioned URL. As it is not mandatory to run a full OPTIMADE implementation from the unversioned URL, by default, this action will not perform any validation of this URL, beyond checking the mandatory `/versions` endpoint. | Optional | `false` | `v2.3+` |
+| `as type` | Validate the request URL with the provided type, rather than scanning the entire implementation.<br>Example values: `structures`, `reference`. For a full list of values see the [OPTIMADE Python tools documentation](https://www.optimade.org/optimade-python-tools/api_reference/validator/validator/#optimade.validator.validator.ImplementationValidator.__init__).<br>It is expected that `path` points to the exact endpoint to be validated. You must include any versions or similar if desired, as the `path` will be used as given.<br>**NB**: This input takes precedence over `all versioned paths`, `validate unversioned path`, and `index`, meaning these will be _ignored_ if `as type` is defined. | Optional | - | `v1+` |
+| `domain` | Domain for the OPTIMADE URL (defaults to the GitHub Actions runner host). | Optional | `gh_actions_host` | `v1+` |
+| `fail fast` | Whether or not to exit and return a non-zero error code on first failure. | Optional | `false` | `v2+` |
+| `index` | Whether or not this is an index meta-database. | Optional | `false` | `v1+` |
+| `path` | Path to append to the domain to reach the OPTIMADE unversioned base URL - MUST start with `/`.<br>The path MUST NOT include the versioned part of the base URL. Rather, it MUST point to the unversioned base URL of your OPTIMADE implementation (**except** if `as type` is defined, then `path` should define the full path to the endpoint to be validated, including also the versioned part if desired, e.g., `/v1.0/structures`). | Optional | `/` | `v1+` |
+| `port` | Port for the OPTIMADE URL. | Optional | `5000` | `v1+` |
+| `protocol` | Protocol for the OPTIMADE URL. | Optional | `http` | `v1+` |
+| `skip optional` | Whether or not to skip tests for optional features. | Optional | `false` | `v2+` |
+| `minimal` | Whether or not to reduce the validation to a minimal test set that only checks responses and not filters. | Optional | `false` | `v2.4.1+` |
+| `validator version` | Full version of an OPTIMADE Python tools release to PyPI, e.g., `'v0.6.0'` or `'0.3.4'`, which hosts the `optimade-validator`. It can also be a branch, tag, or git commit to use from the GitHub repository, e.g., `'master'` or `'5a5e903'`.<br>See [the pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#git) for more information of what is allowed here.<br>Finally, it may also be `'latest'` (default), which is understood to be the latest official release of the `optimade` package on PyPI.<br>Note, for the latest development version, choose `'master'`. | **Required** | `latest` | `v1+` |
+| `verbosity` | The verbosity of the output.<br>`0`: minimalistic, `1`: informational, `2`+: debug | Optional | `1` | `v1+` |
 
 ## Running test suite (developers)
 

--- a/README.md
+++ b/README.md
@@ -90,16 +90,24 @@ The test suite is based on [BATS](https://github.com/bats-core/bats-core) and sh
 The reason to run in Docker, is that the `entrypoint.sh` file will install the `optimade` package.
 And to not pollute your local environment, it is safer to run it in a Docker container.
 
+Furthermore, for each test run, the `optimade` package will be installed in a virtual environment within the Docker file, since changing the `optimade` version is part of the test suite.
+
 Steps to setup your test environment:
 
+1. Git clone the bats-core repository to your local environment
 1. Git clone this repository to your local environment
 1. Install Docker (this depends on your OS, see [the Docker documentation](https://docs.docker.com/install/))
-1. Run in a terminal (based on a Unix system):
+1. Build the Docker images (based on a Unix system):
 
-   ```sh
-   cd /path/to/optimade-validator-action
-   docker build --tag optimade_bats ./tests
-   ```
+  ```sh
+  cd /path/to/bats-core
+  docker build --tag materials-consortia/bats:1.11.0 --build-arg bashver=alpine3.15 .
+
+  cd /path/to/optimade-validator-action
+  docker build --tag optimade_bats ./tests
+  ```
+
+> **Note**: It is necessary to build the `bats-core` image first, since the `optimade-validator-action` image requires at minimum Python 3.9, so the `alpine3.15` image is used.
 
 Now you can run
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,19 +1,20 @@
-FROM bats/bats:v1.10.0
+FROM materials-consortia/bats:1.11.0
 
-RUN echo "**** Installing Python 3 ****" && \
-    apk add --no-cache python3 && \
+ENV PYTHONUNBUFFERED 1
+# Install Python 3
+RUN apk add --update --no-cache python3 && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
-    echo "**** Installing pip ****" && \
+# Install pip and pipx
     python -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --no-cache --upgrade pip setuptools wheel && \
+    pip3 install --no-cache --upgrade pip setuptools wheel virtualenv && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi
 
 ENV BATS_TEST_HELPERS /test_helpers
-RUN echo "**** Updating BATS with bats-support and bats-assert ****" && \
-    apk add --no-cache git && \
+# Install git and update BATS with bats-support and bats-assert
+RUN apk add --no-cache git && \
     git clone https://github.com/bats-core/bats-support ${BATS_TEST_HELPERS}/bats-support && \
     git clone https://github.com/bats-core/bats-assert ${BATS_TEST_HELPERS}/bats-assert
 
-RUN echo "**** Imitating the Action's Dockerfile, retrieving Docker host IP ****" && \
-    echo $(ip route | awk '{print $3}') > /docker_host_ip
+# Imitate the Action's Dockerfile, retrieving the Docker host IP
+RUN echo $(ip route | awk '{print $3}') > /docker_host_ip

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -1,0 +1,32 @@
+## Setup suite (setup/teardown) to run before all files and tests
+
+# Set workdir to Docker default if not set already
+if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
+    export DOCKER_BATS_WORKDIR=/code
+fi
+
+# Absolute path to entrypoint.sh
+export REAL_ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/entrypoint.sh
+export ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/tests/.entrypoint.sh
+
+function setup_suite() {
+    # Clean up any previous test entrypoint.sh
+    rm -f ${ENTRYPOINT_SH}
+
+    # Create BATS test entrypoint.sh at ${ENTRYPOINT_SH}
+    while IFS="" read -r line || [ -n "${line}" ]; do
+        if [[ "${line}" =~ ^set[[:blank:]]-e$ ]]; then
+            # Comment out "set -e" from entrypoint.sh in a new test entrypoint.sh
+            line="# ${line}"
+        fi
+        if [[ "${line}" =~ ^.*helper\.py.*$ ]]; then
+            line="${line/\/helper\.py/helper.py}"
+        fi
+        printf "%s\n" "${line}" >> ${ENTRYPOINT_SH}
+    done < ${REAL_ENTRYPOINT_SH}
+    chmod +x ${ENTRYPOINT_SH}
+}
+
+function teardown_suite() {
+    rm -f ${ENTRYPOINT_SH}
+}

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -3,15 +3,11 @@ if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
     export DOCKER_BATS_WORKDIR=/code
 fi
 
-# Absolute path to entrypoint.sh
-export REAL_ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/entrypoint.sh
-export ENTRYPOINT_SH=${DOCKER_BATS_WORKDIR}/tests/.entrypoint.sh
-
 # Load BATS extensions (installed in ./tests/Dockerfile)
 load "${BATS_TEST_HELPERS}/bats-support/load.bash"
 load "${BATS_TEST_HELPERS}/bats-assert/load.bash"
 
-function setup_file() {
+function setup() {
     # Set all input parameter defaults
     export INPUT_ALL_VERSIONED_PATHS=false
     export INPUT_VALIDATE_UNVERSIONED_PATH=false
@@ -32,26 +28,8 @@ function setup_file() {
 
     # Clean "cache"
     rm -f ${DOCKER_BATS_WORKDIR}/.entrypoint-run_validator.txt
-    rm -f ${ENTRYPOINT_SH}
-
-    # Create BATS test entrypoint.sh at ${ENTRYPOINT_SH}
-    while IFS="" read -r line || [ -n "${line}" ]; do
-        if [[ "${line}" =~ ^set[[:blank:]]-e$ ]]; then
-            # Comment out "set -e" from entrypoint.sh in a new test entrypoint.sh
-            line="# ${line}"
-        fi
-        if [[ "${line}" =~ ^.*helper\.py.*$ ]]; then
-            line="${line/\/helper\.py/helper.py}"
-        fi
-        printf "%s\n" "${line}" >> ${ENTRYPOINT_SH}
-    done < ${REAL_ENTRYPOINT_SH}
-    chmod +x ${ENTRYPOINT_SH}
 }
 
 function teardown() {
     rm -f ${DOCKER_BATS_WORKDIR}/.entrypoint-run_validator.txt
-}
-
-function teardown_file() {
-    rm -f ${ENTRYPOINT_SH}
 }


### PR DESCRIPTION
Fixes #142
Fixes #123 

By git cloning the [bats-core](https://github.com/bats-core/bats-core) repository locally and building the Dockerfile with the build argument `bashver` to point to a specific [bash Docker image](https://hub.docker.com/_/bash) tag, it is possible to use a specific alpine version, which in turn let's us use a specific Python version.

We want to use the latest possible alpine version that uses Python 3.9 (as this is currently the minimum supported version for OPTIMADE Python tools). This alpine version is 3.15 (see the [packages overview](https://pkgs.alpinelinux.org/packages) for confirmation, searching for `python3`, changing the branch accordingly).

Another, future, solution here, would be to build the custom BATS Docker image "once" and upload it to the GitHub container repository and use it there. I suggest doing this in another PR, however, for now. An issue should be opened for this around the merge-time of this PR.

Finally, as a bonus, the `set-output` usage has been replaced with redirecting to the `GITHUB_OUTPUT` environment variable (if the `GITHUB_ACTIONS` environment variable is `true`, as it will always be when running in GitHub Actions).