### PR TITLE
Use the newly created bats image on ghcr.io

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -154,6 +154,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Run BATS test suite for entrypoint.sh
 
+    permissions:
+      packages: read
+
     env:
       # Latest BATS version
       # If a new BATS version is released, a new Docker image should be built

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -169,7 +169,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build BATS environment
-        run: docker build -t optimade_bats ./tests
+        run: |
+          docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker build -t optimade_bats ./tests
 
       - name: Run BATS tests
         run: ./run_tests.sh

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -156,36 +156,20 @@ jobs:
 
     env:
       # Latest BATS version
-      # This should manually be updated when a new version is released
-      # Tries to match the latest Docker tag for the BATS image at:
-      # https://hub.docker.com/r/bats/bats/tags
+      # If a new BATS version is released, a new Docker image should be built
+      # and uploaded to ghcr.io/materials-consortia/bats with the new version tag
+      # as well as an approprate alpine version (using the `bashver` build arg).
       BATS_VERSION: '1.11.0'
-      # The latest alpine version with Python3.9
-      # For more information use the alpine package search:
-      # https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.15
-      BASH_DOCKER_TAG: alpine3.15
 
     steps:
-      - name: Checkout bats-core/bats-core
+      - name: Checkout the repository
         uses: actions/checkout@v4
-        with:
-          repository: bats-core/bats-core
-          path: bats-core
-
-      - name: Build BATS Docker image
-        run: docker build -t materials-consortia/bats:${{ env.BATS_VERSION }} --build-arg bashver=${{ env.BASH_DOCKER_TAG }} ./bats-core
-
-      - name: Checkout the local repository
-        uses: actions/checkout@v4
-        with:
-          path: main
 
       - name: Build BATS environment
-        run: docker build -t optimade_bats ./main/tests
+        run: docker build -t optimade_bats ./tests
 
       - name: Run BATS tests
         run: ./run_tests.sh
-        working-directory: main
 
   validator_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -168,10 +168,22 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghrc.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build BATS environment
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker build -t optimade_bats ./tests
+        uses: docker/build-push-action@v5
+        with:
+          context: ./tests
+          push: false
+          tags: optimade_bats
 
       - name: Run BATS tests
         run: ./run_tests.sh

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build BATS environment
         run: |
-          docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -t optimade_bats ./tests
 
       - name: Run BATS tests

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -183,6 +183,7 @@ jobs:
         with:
           context: ./tests
           push: false
+          load: true
           tags: optimade_bats
 
       - name: Run BATS tests

--- a/README.md
+++ b/README.md
@@ -96,9 +96,14 @@ Steps to setup your test environment:
 
 1. Git clone this repository to your local environment
 1. Install Docker (this depends on your OS, see [the Docker documentation](https://docs.docker.com/install/))
+1. Ensure you are a member of the GitHub organization [Materials-Consortia](https://github.com/Materials-Consortia).
+  This is necessary to pull the base image for the Docker image for testing.
 1. Build the Docker image for testing (based on a Unix system):
 
   ```sh
+  docker login ghcr.io
+  # You will be prompted for your GitHub username and password
+
   cd /path/to/optimade-validator-action
   docker build --tag optimade_bats ./tests
   ```

--- a/README.md
+++ b/README.md
@@ -94,20 +94,14 @@ Furthermore, for each test run, the `optimade` package will be installed in a vi
 
 Steps to setup your test environment:
 
-1. Git clone the bats-core repository to your local environment
 1. Git clone this repository to your local environment
 1. Install Docker (this depends on your OS, see [the Docker documentation](https://docs.docker.com/install/))
-1. Build the Docker images (based on a Unix system):
+1. Build the Docker image for testing (based on a Unix system):
 
   ```sh
-  cd /path/to/bats-core
-  docker build --tag materials-consortia/bats:1.11.0 --build-arg bashver=alpine3.15 .
-
   cd /path/to/optimade-validator-action
   docker build --tag optimade_bats ./tests
   ```
-
-> **Note**: It is necessary to build the `bats-core` image first, since the `optimade-validator-action` image requires at minimum Python 3.9, so the `alpine3.15` image is used.
 
 Now you can run
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM materials-consortia/bats:1.11.0
+FROM ghcr.io/materials-consortia/bats:1.11.0
 
 ENV PYTHONUNBUFFERED 1
 # Install Python 3


### PR DESCRIPTION
A Docker image for BATS, based on BATS v1.11.0 and using `bashver=alpine3.15` has been uploaded to
ghcr.io/materials-consortia/bats, with the tags `latest` and `1.11.0` - the latter mimicking the tag for the "proper" bats/bats image.

Closes #146 