### PR TITLE
Bump Python to 3.10

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -21,10 +21,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,7 +8,7 @@ on:
     - 'push-action/**'
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.10
 
 jobs:
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,7 +8,7 @@ on:
     - 'push-action/**'
 
 env:
-  PYTHON_VERSION: 3.10
+  PYTHON_VERSION: "3.10"
 
 jobs:
 
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ env.PYTHON_VERSION }}'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python dependencies
         run: |
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ env.PYTHON_VERSION }}'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python dependencies
         run: |
@@ -257,10 +257,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run action to retrieve output
         id: action

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.10-slim-buster
 
 RUN apt update && apt install -y iproute2
 RUN ["/bin/bash", "-c", "set -o pipefail && ip route | awk '{print $3}' > docker_host_ip"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 ignore_missing_imports = true
 scripts_are_modules = true
 warn_unused_configs = true


### PR DESCRIPTION
Hi @CasperWA, I'm in the process of removing Python 3.9 support for optimade-python-tools (https://github.com/Materials-Consortia/optimade-python-tools/pull/2158). Can we do the same here please?