### PR TITLE
Use the BATS GitHub action

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -158,37 +158,26 @@ jobs:
     permissions:
       packages: read
 
-    env:
-      # Latest BATS version
-      # If a new BATS version is released, a new Docker image should be built
-      # and uploaded to ghcr.io/materials-consortia/bats with the new version tag
-      # as well as an approprate alpine version (using the `bashver` build arg).
-      BATS_VERSION: '1.11.0'
-
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghrc.io
-        uses: docker/login-action@v3
+      - name: Setup BATS and BATS libs
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build BATS environment
-        uses: docker/build-push-action@v6
-        with:
-          context: ./tests
-          push: false
-          load: true
-          tags: optimade_bats
+          support-install: true
+          support-path: "${{ github.workspace }}/tests/bats-support"
+          assert-install: true
+          assert-path: "${{ github.workspace }}/tests/bats-assert"
+          detik-install: false
+          file-install: false
 
       - name: Run BATS tests
-        run: ./run_tests.sh
+        shell: bash
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+        run: bats ./tests
 
   validator_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -178,6 +178,12 @@ jobs:
           detik-install: false
           file-install: false
 
+      - name: Imitate the Action's Dockerfile
+        shell: bash
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends -fqqy iproute2
+          set -o pipefail && ip route | awk '{print $3}' > /tmp/docker_host_ip
+
       - name: Run BATS tests
         shell: bash
         env:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -184,6 +184,9 @@ jobs:
           sudo apt-get update && sudo apt-get install --no-install-recommends -fqqy iproute2
           set -o pipefail && ip route | awk '{print $3}' > /tmp/docker_host_ip
 
+          python -m pip install -U pip
+          pip install -U setuptools wheel virtualenv
+
       - name: Run BATS tests
         shell: bash
         env:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -162,6 +162,11 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
+      - name: Install Python 3.10 (minimum supported OPT version)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
       - name: Setup BATS and BATS libs
         id: setup-bats
         uses: bats-core/bats-action@3.0.0

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -181,11 +181,13 @@ jobs:
       - name: Imitate the Action's Dockerfile
         shell: bash
         run: |
-          sudo apt-get update && sudo apt-get install --no-install-recommends -fqqy iproute2
+          echo "Installing iproute2 and getting the host IP address"
+          sudo apt-get -qq update && sudo apt-get install --no-install-recommends -fqqy iproute2
           set -o pipefail && ip route | awk '{print $3}' > /tmp/docker_host_ip
 
-          python -m pip install -U pip
-          pip install -U setuptools wheel virtualenv
+          echo "Installing Python dependencies"
+          python -m pip install -U -q pip
+          pip install -U -q setuptools wheel virtualenv
 
       - name: Run BATS tests
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-buster
 
 RUN apt update && apt install -y iproute2
-RUN ["/bin/bash", "-c", "set -o pipefail && ip route | awk '{print $3}' > docker_host_ip"]
+RUN ["/bin/bash", "-c", "set -o pipefail && ip route | awk '{print $3}' > /tmp/docker_host_ip"]
 
 RUN python -m pip install --upgrade pip && \
     pip install setuptools wheel virtualenv

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,10 @@ set -e
 set -o pipefail
 
 # Setup and activate virtual environment
-rm -rf /venvs
-mkdir -p /venvs
-python -m virtualenv /venvs/optimade-validator
-source /venvs/optimade-validator/bin/activate
+rm -rf /tmp/venvs
+mkdir -p /tmp/venvs
+python -m virtualenv /tmp/venvs/optimade-validator
+source /tmp/venvs/optimade-validator/bin/activate
 
 # Install OPTIMADE Python tools
 if [ "${INPUT_VALIDATOR_VERSION}" = "latest" ]; then
@@ -33,7 +33,7 @@ if [ ${PACKAGE_VERSION[0]} -eq 0 ] && [ ${PACKAGE_VERSION[1]} -lt 10 ]; then
 fi
 
 # Retrieve and add GitHub Actions host runner IP to known hosts
-DOCKER_HOST_IP=$(cat /docker_host_ip)
+DOCKER_HOST_IP=$(cat /tmp/docker_host_ip)
 echo ${DOCKER_HOST_IP} gh_actions_host >> /etc/hosts
 
 run_validator="optimade-validator"
@@ -208,6 +208,6 @@ fi
 
 # Deactivate and remove virtual environment
 deactivate
-rm -rf /venvs
+rm -rf /tmp/venvs
 
 exit ${EXIT_CODE}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -17,4 +17,4 @@ RUN apk add --no-cache git && \
     git clone https://github.com/bats-core/bats-assert ${BATS_TEST_HELPERS}/bats-assert
 
 # Imitate the Action's Dockerfile, retrieving the Docker host IP
-RUN echo $(ip route | awk '{print $3}') > /docker_host_ip
+RUN echo $(ip route | awk '{print $3}') > /tmp/docker_host_ip

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/materials-consortia/bats:1.11.0
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 # Install Python 3
 RUN apk add --update --no-cache python3 && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
@@ -10,7 +10,7 @@ RUN apk add --update --no-cache python3 && \
     pip3 install --no-cache --upgrade pip setuptools wheel virtualenv && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi
 
-ENV BATS_TEST_HELPERS /test_helpers
+ENV BATS_TEST_HELPERS=/test_helpers
 # Install git and update BATS with bats-support and bats-assert
 RUN apk add --no-cache git && \
     git clone https://github.com/bats-core/bats-support ${BATS_TEST_HELPERS}/bats-support && \

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -2,7 +2,11 @@
 
 # Set workdir to Docker default if not set already
 if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
-    export DOCKER_BATS_WORKDIR=/code
+    if [ -n "${CI}" ]; then
+        export DOCKER_BATS_WORKDIR=${GITHUB_WORKSPACE}
+    else
+        export DOCKER_BATS_WORKDIR=/code
+    fi
 fi
 
 # Absolute path to entrypoint.sh

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -1,6 +1,10 @@
 # Set workdir to Docker default if not set already
 if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
-    export DOCKER_BATS_WORKDIR=/code
+    if [ -n "${CI}" ]; then
+        export DOCKER_BATS_WORKDIR=${GITHUB_WORKSPACE}
+    else
+        export DOCKER_BATS_WORKDIR=/code
+    fi
 fi
 
 # Load BATS extensions (installed in ./tests/Dockerfile)

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -4,11 +4,11 @@ if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
 fi
 
 # Load BATS extensions (installed in ./tests/Dockerfile)
-if [ -n "${BATS_LIB_PATH}" ]; then
-    export BATS_TEST_HELPERS=${BATS_LIB_PATH}
+if [ -z "${BATS_LIB_PATH}" ]; then
+    export BATS_LIB_PATH=${BATS_TEST_HELPERS}
 fi
-load "${BATS_TEST_HELPERS}/bats-support/load.bash"
-load "${BATS_TEST_HELPERS}/bats-assert/load.bash"
+bats_load_library bats-support
+bats_load_library bats-assert
 
 function setup() {
     # Set all input parameter defaults

--- a/tests/test_fixtures.bash
+++ b/tests/test_fixtures.bash
@@ -4,6 +4,9 @@ if [ -z "${DOCKER_BATS_WORKDIR}" ]; then
 fi
 
 # Load BATS extensions (installed in ./tests/Dockerfile)
+if [ -n "${BATS_LIB_PATH}" ]; then
+    export BATS_TEST_HELPERS=${BATS_LIB_PATH}
+fi
 load "${BATS_TEST_HELPERS}/bats-support/load.bash"
 load "${BATS_TEST_HELPERS}/bats-assert/load.bash"
 


### PR DESCRIPTION
Fixes #164 by using the [BATS GitHub Actions](https://github.com/bats-core/bats-action) to run BATS in the CI.

Testing it locally, the same issue will arise due to the test image used for BATS runs with Python 3.9.
So either this testing possibility should be removed, or the image should either be updated to use a newer alpine version or be completely rewritten - something that should not be too hard. One could, e.g., base it on the BATS GitHub action composite action that expects a Linux environment and then goes to town.

## Copilot summary

This pull request includes several changes to the CI workflow, Docker setup, and test configurations. The main focus is on improving the setup and execution of BATS tests and ensuring compatibility with the CI environment.

### CI Workflow Improvements:
* [`.github/workflows/ci_tests.yml`](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL161-R194): Removed Docker setup steps and added steps to install Python 3.10, setup BATS, and install necessary dependencies.

### Dockerfile Adjustments:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R4): Changed the location of the `docker_host_ip` file to `/tmp/docker_host_ip`.
* [`tests/Dockerfile`](diffhunk://#diff-ee90f1ed18a2fa072314c56e0b427d1be10d1925c67e2c19f91e92632a89b839L20-R20): Updated the location for storing `docker_host_ip` to `/tmp/docker_host_ip`.

### Entrypoint Script Changes:
* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L6-R9): Updated the virtual environment setup to use `/tmp/venvs` instead of `/venvs` and modified the retrieval of `docker_host_ip` to use `/tmp/docker_host_ip`. [[1]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L6-R9) [[2]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L36-R36) [[3]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L211-R211)

### Test Configuration Updates:
* `tests/setup_suite.bash` and `tests/test_fixtures.bash`: Added conditional logic to set `DOCKER_BATS_WORKDIR` based on the CI environment and updated BATS library loading. [[1]](diffhunk://#diff-39da738ebed99e36eae77d43b52dccb6c98af0dfedb9143bbc57b7c7f92a4fdeR5-R10) [[2]](diffhunk://#diff-02b82e7e9742d5744d2c4dcff7b5ae604c0655a10a2ee463a25232ab78a950d1R3-R15)